### PR TITLE
Add SaveStateHandle support via pure Kotlin StateHandle abstraction

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -44,6 +44,7 @@ accompanist-navigation-animation = { module = "com.google.accompanist:accompanis
 androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "coreKtx" }
 androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "lifecycleRuntimeKtx" }
 androidx-lifecycle-viewmodel-compose = { module = "androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "lifecycleRuntimeKtx" }
+androidx-lifecycle-viewmodel-savedstate = { module = "androidx.lifecycle:lifecycle-viewmodel-savedstate", version.ref = "lifecycleRuntimeKtx" }
 androidx-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "compose" }
 auto-service = { module = "com.google.auto.service:auto-service", version.ref = "autoService" }
 javapoet = { module = "com.squareup:javapoet", version.ref = "javapoet" }

--- a/yamv-viewmodel/build.gradle.kts
+++ b/yamv-viewmodel/build.gradle.kts
@@ -2,6 +2,8 @@ plugins {
     id("com.android.library")
     id("org.jetbrains.kotlin.android")
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.hilt)
+    alias(libs.plugins.ksp)
 }
 
 android {
@@ -32,10 +34,14 @@ dependencies {
     api(project(":yamv"))
     implementation(project(":core"))
     implementation(libs.androidx.lifecycle.viewmodel.compose)
+    implementation(libs.androidx.lifecycle.viewmodel.savedstate)
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.androidx.compose.hilt)
     implementation(libs.androidx.compose.ui)
     implementation(libs.androidx.compose.preview)
+
+    implementation(libs.dagger.hilt.android)
+    ksp(libs.dagger.hilt.android.compiler)
 
     testImplementation(libs.bundles.testing.unit)
 }

--- a/yamv-viewmodel/src/main/kotlin/com/ktomek/yamv/viewmodel/AndroidStateHandle.kt
+++ b/yamv-viewmodel/src/main/kotlin/com/ktomek/yamv/viewmodel/AndroidStateHandle.kt
@@ -1,0 +1,13 @@
+package com.ktomek.yamv.viewmodel
+
+import androidx.lifecycle.SavedStateHandle
+import com.ktomek.yamv.state.StateHandle
+import kotlinx.coroutines.flow.StateFlow
+
+class AndroidStateHandle(private val handle: SavedStateHandle) : StateHandle {
+    override fun <T : Any> get(key: String): T? = handle[key]
+    override fun <T : Any> set(key: String, value: T) { handle[key] = value }
+    override fun contains(key: String): Boolean = handle.contains(key)
+    override fun <T : Any> getStateFlow(key: String, initialValue: T): StateFlow<T> =
+        handle.getStateFlow(key, initialValue)
+}

--- a/yamv-viewmodel/src/main/kotlin/com/ktomek/yamv/viewmodel/YamvStateHandleModule.kt
+++ b/yamv-viewmodel/src/main/kotlin/com/ktomek/yamv/viewmodel/YamvStateHandleModule.kt
@@ -1,0 +1,18 @@
+package com.ktomek.yamv.viewmodel
+
+import androidx.lifecycle.SavedStateHandle
+import com.ktomek.yamv.state.StateHandle
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ViewModelComponent
+import dagger.hilt.android.scopes.ViewModelScoped
+
+@Module
+@InstallIn(ViewModelComponent::class)
+object YamvStateHandleModule {
+    @Provides
+    @ViewModelScoped
+    fun provideStateHandle(savedStateHandle: SavedStateHandle): StateHandle =
+        AndroidStateHandle(savedStateHandle)
+}

--- a/yamv/src/main/kotlin/com/ktomek/yamv/state/StateHandle.kt
+++ b/yamv/src/main/kotlin/com/ktomek/yamv/state/StateHandle.kt
@@ -1,0 +1,19 @@
+package com.ktomek.yamv.state
+
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+interface StateHandle {
+    operator fun <T : Any> get(key: String): T?
+    operator fun <T : Any> set(key: String, value: T)
+    fun contains(key: String): Boolean
+    fun <T : Any> getStateFlow(key: String, initialValue: T): StateFlow<T>
+}
+
+object EmptyStateHandle : StateHandle {
+    override fun <T : Any> get(key: String): T? = null
+    override fun <T : Any> set(key: String, value: T) = Unit
+    override fun contains(key: String): Boolean = false
+    override fun <T : Any> getStateFlow(key: String, initialValue: T): StateFlow<T> =
+        MutableStateFlow(initialValue)
+}


### PR DESCRIPTION
## Summary

- Adds `StateHandle` interface (`get`/`set`/`contains`/`getStateFlow`) in `:yamv` — pure Kotlin, no Android deps
- Adds `EmptyStateHandle` no-op singleton for safe defaults
- Adds `AndroidStateHandle` in `:yamv-viewmodel` wrapping `SavedStateHandle`, including reactive `getStateFlow`
- Adds `YamvStateHandleModule` — a single Hilt module providing `StateHandle` at `@ViewModelScoped`
- Configures Hilt plugin + KSP compiler in `:yamv-viewmodel`

## Design

Features opt in to state persistence simply by injecting `StateHandle` in their constructor — no special interface, no mutable properties, no changes to `MviRuntime` or KSP-generated Store classes.

```kotlin
class MyFeature @Inject constructor(
    private val stateHandle: StateHandle,
) : Feature.FlowFeature<MyState> {
    override fun invoke(intentions: Flow<Any>): Flow<Outcome<MyState>> =
        intentions
            .filter { ... }
            .scan(stateHandle["key"] ?: 0) { acc, it -> ... }
            .onEach { value -> stateHandle["key"] = value }
            ...
            .onStart { emit(StateOutcome { it.copy(...) }) }
}
```

## Test plan

- [ ] `./gradlew :yamv:test` — existing tests pass unchanged
- [ ] `./gradlew :app:kspDebugKotlin` — generated Store classes unchanged
- [ ] `./gradlew :app:assembleDebug` — app builds with Hilt wiring resolved