### PR TITLE
feat: FeatureRegistrar — hide .wrap() in Koin mviStore DSL

### DIFF
--- a/app/koin/src/commonMain/kotlin/com/ktomek/yamv/koin/counter/CounterFeaturesModule.kt
+++ b/app/koin/src/commonMain/kotlin/com/ktomek/yamv/koin/counter/CounterFeaturesModule.kt
@@ -1,6 +1,5 @@
 package com.ktomek.yamv.koin.counter
 
-import com.ktomek.yamv.feature.wrap
 import com.ktomek.yamv.koin.counter.logic.feature.AutoDecreaseFeature
 import com.ktomek.yamv.koin.counter.logic.feature.AutoIncreaseFeature
 import com.ktomek.yamv.koin.counter.logic.feature.DecreaseFeature
@@ -15,11 +14,9 @@ val counterModule = module {
     factory { AutoIncreaseFeature(get()) }
 
     mviStore(defaultState = CounterState()) {
-        setOf(
-            get<AutoDecreaseFeature>(),
-            get<AutoIncreaseFeature>(),
-            get<DecreaseFeature>().wrap(),
-            increaseFeature,
-        )
+        add(get<AutoDecreaseFeature>())
+        add(get<AutoIncreaseFeature>())
+        add(get<DecreaseFeature>())
+        add(increaseFeature)
     }
 }

--- a/yamv-koin/src/commonMain/kotlin/com/ktomek/yamv/koin/FeatureRegistrar.kt
+++ b/yamv-koin/src/commonMain/kotlin/com/ktomek/yamv/koin/FeatureRegistrar.kt
@@ -1,0 +1,49 @@
+package com.ktomek.yamv.koin
+
+import com.ktomek.yamv.core.State
+import com.ktomek.yamv.feature.ActionTypedFeature
+import com.ktomek.yamv.feature.Feature
+import com.ktomek.yamv.feature.FunctionTypedFeature
+import com.ktomek.yamv.feature.TypedFeature
+import com.ktomek.yamv.feature.wrap
+import org.koin.core.scope.Scope
+
+/**
+ * Builder that assembles a [Set]<[Feature]<[S]>> for use in [mviStore].
+ *
+ * Call [add] for each feature. For typed feature interfaces ([FunctionTypedFeature],
+ * [ActionTypedFeature], [TypedFeature]) the required `.wrap()` is applied automatically —
+ * no call sites need to know about it.
+ *
+ * Koin dependency resolution is forwarded via the inline [get] function, keeping the same
+ * ergonomics as a plain `Scope.() -> ...` lambda.
+ */
+class FeatureRegistrar<S : State>(@PublishedApi internal val scope: Scope) {
+
+    @PublishedApi internal val features = mutableSetOf<Feature<S>>()
+
+    /** Adds a [Feature]<[S]> directly — [Feature.FlowFeature] and builder results go here. */
+    fun add(feature: Feature<S>) {
+        features.add(feature)
+    }
+
+    /** Adds a [FunctionTypedFeature], applying [wrap] internally. */
+    inline fun <reified I : Any> add(feature: FunctionTypedFeature<S, I>) {
+        features.add(feature.wrap())
+    }
+
+    /** Adds an [ActionTypedFeature], applying [wrap] internally. */
+    inline fun <reified I : Any> add(feature: ActionTypedFeature<S, I>) {
+        features.add(feature.wrap())
+    }
+
+    /** Adds a [TypedFeature], applying [wrap] internally. */
+    inline fun <reified I : Any> add(feature: TypedFeature<S, I>) {
+        features.add(feature.wrap())
+    }
+
+    /** Resolves a Koin dependency — equivalent to calling `get<T>()` inside a [Scope] lambda. */
+    inline fun <reified T : Any> get(): T = scope.get()
+
+    @PublishedApi internal fun build(): Set<Feature<S>> = features.toSet()
+}

--- a/yamv-koin/src/commonMain/kotlin/com/ktomek/yamv/koin/KoinMviStore.kt
+++ b/yamv-koin/src/commonMain/kotlin/com/ktomek/yamv/koin/KoinMviStore.kt
@@ -11,7 +11,6 @@ import org.koin.core.module.Module
 import org.koin.core.module.dsl.viewModel
 import org.koin.core.qualifier.Qualifier
 import org.koin.core.qualifier.named
-import org.koin.core.scope.Scope
 
 /**
  * Generic ViewModel that drives any [State] type through the MVI runtime.
@@ -40,26 +39,30 @@ inline fun <reified S : State> stateQualifier(): Qualifier = named(S::class.simp
 /**
  * Registers a [KoinMviStore] for state type [S] as a Koin ViewModel, qualified by [stateQualifier].
  *
- * Call this inside a `module { }` block. The [features] lambda runs in [Scope] so `get<T>()`
- * is available for retrieving feature instances registered elsewhere in the module.
+ * Call this inside a `module { }` block. The [features] lambda receives a [FeatureRegistrar]
+ * so `add(feature)` and `get<T>()` are available without calling `.wrap()` manually.
  *
  * Usage:
  * ```kotlin
  * val counterModule = module {
  *     factory { AutoDecreaseFeature() }
+ *     factory { DecreaseFeature() }
  *
  *     mviStore(defaultState = CounterState()) {
- *         setOf(get<AutoDecreaseFeature>(), ...)
+ *         add(get<AutoDecreaseFeature>())   // FlowFeature — passed through
+ *         add(get<DecreaseFeature>())       // FunctionTypedFeature — wrapped automatically
  *     }
  * }
  * ```
  */
 inline fun <reified S : State> Module.mviStore(
     defaultState: S,
-    noinline features: Scope.() -> Set<Feature<S>>,
+    crossinline features: FeatureRegistrar<S>.() -> Unit,
 ) {
     viewModel(stateQualifier<S>()) {
-        KoinMviStore(features = features(), defaultState = defaultState)
+        val registrar = FeatureRegistrar<S>(this)
+        registrar.features()
+        KoinMviStore(features = registrar.build(), defaultState = defaultState)
     }
 }
 

--- a/yamv/src/main/kotlin/com/ktomek/yamv/feature/ActionTypedFeatureWrapper.kt
+++ b/yamv/src/main/kotlin/com/ktomek/yamv/feature/ActionTypedFeatureWrapper.kt
@@ -8,7 +8,7 @@ import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.launch
 import kotlin.invoke
 
-inline fun <reified S : State, reified INTENTION> ActionTypedFeature<S, INTENTION>.wrap(): Feature<S> =
+inline fun <S : State, reified INTENTION> ActionTypedFeature<S, INTENTION>.wrap(): Feature<S> =
     object : TypedUnitFeatureHolder<S> {
         override val feature: Any = this@wrap
 

--- a/yamv/src/main/kotlin/com/ktomek/yamv/feature/FunctionTypedFeatureWrapper.kt
+++ b/yamv/src/main/kotlin/com/ktomek/yamv/feature/FunctionTypedFeatureWrapper.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.launch
 
-inline fun <reified S : State, reified INTENTION> FunctionTypedFeature<S, INTENTION>.wrap(): Feature<S> =
+inline fun <S : State, reified INTENTION> FunctionTypedFeature<S, INTENTION>.wrap(): Feature<S> =
     object : TypedFeatureHolder<S> {
         override val feature: Any = this@wrap
 

--- a/yamv/src/main/kotlin/com/ktomek/yamv/feature/TypedFeatureWrapper.kt
+++ b/yamv/src/main/kotlin/com/ktomek/yamv/feature/TypedFeatureWrapper.kt
@@ -4,7 +4,7 @@ import com.ktomek.yamv.core.State
 import kotlinx.coroutines.flow.channelFlow
 import kotlinx.coroutines.flow.filterIsInstance
 
-inline fun <reified S : State, reified INTENTION> TypedFeature<S, INTENTION>.wrap(): Feature<S> =
+inline fun <S : State, reified INTENTION> TypedFeature<S, INTENTION>.wrap(): Feature<S> =
     Feature.FlowFeature<S> { intentions ->
         channelFlow {
             val typedIntentions = intentions.filterIsInstance<INTENTION>()


### PR DESCRIPTION
## Summary
- Adds `FeatureRegistrar<S>` builder to `:yamv-koin` with overloaded `add()` functions for `Feature<S>`, `FunctionTypedFeature`, `ActionTypedFeature`, and `TypedFeature` — `.wrap()` is applied internally so users never call it directly
- Updates `mviStore` DSL to accept `FeatureRegistrar<S>.() -> Unit` instead of `Scope.() -> Set<Feature<S>>`; Koin's `get<T>()` is forwarded via an inline function on `FeatureRegistrar`
- Removes unnecessary `reified S` from all three `.wrap()` extension functions — only `INTENTION` needs reification for `filterIsInstance`

## Test Plan
- [ ] `./gradlew :yamv:jvmTest` passes
- [ ] `./gradlew :app:koin:compileDebugKotlin` builds without errors
- [ ] `./gradlew detektAll` reports no violations