### PR TITLE
docs: add README, MkDocs Material site, and GitHub Pages workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,28 @@
+name: Deploy Docs to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install MkDocs Material
+        run: pip install mkdocs-material
+
+      - name: Deploy to GitHub Pages
+        run: mkdocs gh-deploy --force

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,191 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to the Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by the Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding any notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   Copyright 2024 Krzysztof Tomek
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,118 @@
+# YAMV — Yet Another MVI Framework
+
+[![Build, Test](https://github.com/ktomek/yamv/actions/workflows/ci.yml/badge.svg)](https://github.com/ktomek/yamv/actions/workflows/ci.yml)
+[![JitPack](https://jitpack.io/v/ktomek/yamv.svg)](https://jitpack.io/#ktomek/yamv)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
+A Kotlin-first **MVI (Model-View-Intent)** framework for Android & Kotlin Multiplatform with compile-time code generation via KSP.
+
+- **Reactive** — state management via Kotlin Coroutines & Flow
+- **Type-safe** — sealed intentions, typed features, compile-time generation
+- **Multiplatform** — Android (Hilt or Koin) + iOS (Compose Multiplatform + Koin)
+- **Zero boilerplate** — `@AutoState` + `@AutoFeature` generate the ViewModel and Hilt/Koin modules
+
+## Quick Start
+
+### 1. Add JitPack repository
+
+```kotlin
+// settings.gradle.kts
+dependencyResolutionManagement {
+    repositories {
+        maven { url = uri("https://jitpack.io") }
+    }
+}
+```
+
+### 2. Add dependencies
+
+```kotlin
+// build.gradle.kts (app module)
+dependencies {
+    // Core framework
+    implementation("com.github.ktomek.yamv:yamv:VERSION")
+
+    // Android ViewModel integration
+    implementation("com.github.ktomek.yamv:yamv-viewmodel:VERSION")
+
+    // Choose your DI integration:
+    implementation("com.github.ktomek.yamv:yamv-hilt:VERSION")   // Hilt
+    // or
+    implementation("com.github.ktomek.yamv:yamv-koin:VERSION")   // Koin (multiplatform)
+
+    // KSP code generation (Hilt only)
+    ksp("com.github.ktomek.yamv:processor-hilt:VERSION")
+}
+```
+
+Replace `VERSION` with the latest badge version above.
+
+### 3. Define your state and intentions
+
+```kotlin
+// State
+@AutoState
+data class CounterState(val count: Int = 0) : State
+
+// Intentions
+sealed class CounterIntention {
+    data object Increment : CounterIntention()
+    data object Decrement : CounterIntention()
+}
+```
+
+### 4. Write a feature
+
+```kotlin
+@AutoFeature
+class IncrementFeature : TypedFeature<CounterState, CounterIntention.Increment> {
+    override fun invoke(intentions: Flow<CounterIntention.Increment>): Flow<Outcome<CounterState>> =
+        intentions.map { StateOutcome { it.copy(count = it.count + 1) } }
+}
+```
+
+### 5. Collect state in your Composable
+
+```kotlin
+@Composable
+fun CounterScreen(vm: CounterStateStore = hiltMviStore()) {
+    val state by vm.state.collectAsStateWithLifecycle()
+
+    Column {
+        Text("Count: ${state.count}")
+        Button(onClick = { vm.dispatch(CounterIntention.Increment) }) {
+            Text("+")
+        }
+    }
+}
+```
+
+That's it. `@AutoState` generates `CounterStateStore` and `@AutoFeature` generates the Hilt bindings.
+
+## Modules
+
+| Module | Description | Platform |
+|--------|-------------|----------|
+| `core` | Marker interfaces & annotations (`State`, `Outcome`, `@AutoState`, `@AutoFeature`) | Pure Kotlin |
+| `yamv` | Core runtime (`MviRuntime`, `MviStore`, `FeatureRouter`) | Kotlin Multiplatform |
+| `yamv-viewmodel` | `MviViewModel` base class | Android + iOS |
+| `yamv-hilt` | `hiltMviStore()` Compose helper | Android |
+| `yamv-koin` | `koinMviStore()` Compose helper | Kotlin Multiplatform |
+| `processor-core` | KSP utilities (DI-agnostic) | JVM |
+| `processor-hilt` | Hilt KSP processor — generates `*Store` + `*FeaturesModule` | JVM |
+
+## Documentation
+
+Full documentation: **[ktomek.github.io/yamv](https://ktomek.github.io/yamv)**
+
+- [Getting Started](https://ktomek.github.io/yamv/getting-started/)
+- [Architecture](https://ktomek.github.io/yamv/architecture/)
+- [Features Guide](https://ktomek.github.io/yamv/features/)
+- [Code Generation](https://ktomek.github.io/yamv/code-generation/)
+- [Multiplatform Setup](https://ktomek.github.io/yamv/multiplatform/)
+
+## License
+
+```
+MIT License — see LICENSE file
+```

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ A Kotlin-first **MVI (Model-View-Intent)** framework for Android & Kotlin Multip
 - **Reactive** — state management via Kotlin Coroutines & Flow
 - **Type-safe** — sealed intentions, typed features, compile-time generation
 - **Multiplatform** — Android (Hilt or Koin) + iOS (Compose Multiplatform + Koin)
-- **Zero boilerplate** — `@AutoState` + `@AutoFeature` generate the ViewModel and Hilt/Koin modules
+- **Zero boilerplate** — `@AutoState` + `@AutoFeature` generate the retained store and Hilt/Koin modules
 
 ## Quick Start
 
@@ -33,7 +33,7 @@ dependencies {
     implementation("com.github.ktomek.yamv:yamv:VERSION")
 
     // Android ViewModel integration
-    implementation("com.github.ktomek.yamv:yamv-viewmodel:VERSION")
+    implementation("com.github.ktomek.yamv:yamv-retainer:VERSION")
 
     // Choose your DI integration:
     implementation("com.github.ktomek.yamv:yamv-hilt:VERSION")   // Hilt
@@ -50,24 +50,31 @@ Replace `VERSION` with the latest badge version above.
 ### 3. Define your state and intentions
 
 ```kotlin
-// State
 @AutoState
 data class CounterState(val count: Int = 0) : State
 
-// Intentions
 sealed class CounterIntention {
     data object Increment : CounterIntention()
     data object Decrement : CounterIntention()
 }
 ```
 
-### 4. Write a feature
+### 4. Define reducers and features
+
+Declare reducers as separate classes — decoupled from features, independently testable:
 
 ```kotlin
+// Reducer — pure (S) -> S, tested without coroutines
+class IncrementReducer : StateOutcome<CounterState> {
+    override fun reduce(prevState: CounterState) =
+        prevState.copy(count = prevState.count + 1)
+}
+
+// Feature — maps intentions to outcomes
 @AutoFeature
 class IncrementFeature : TypedFeature<CounterState, CounterIntention.Increment> {
     override fun invoke(intentions: Flow<CounterIntention.Increment>): Flow<Outcome<CounterState>> =
-        intentions.map { StateOutcome { it.copy(count = it.count + 1) } }
+        intentions.map { IncrementReducer() }
 }
 ```
 
@@ -95,9 +102,9 @@ That's it. `@AutoState` generates `CounterStateStore` and `@AutoFeature` generat
 |--------|-------------|----------|
 | `core` | Marker interfaces & annotations (`State`, `Outcome`, `@AutoState`, `@AutoFeature`) | Pure Kotlin |
 | `yamv` | Core runtime (`MviRuntime`, `MviStore`, `FeatureRouter`) | Kotlin Multiplatform |
-| `yamv-viewmodel` | `MviViewModel` base class | Android + iOS |
+| `yamv-retainer` | `MviRetainedStore` — lifecycle-retained ViewModel base | Android + iOS |
 | `yamv-hilt` | `hiltMviStore()` Compose helper | Android |
-| `yamv-koin` | `koinMviStore()` Compose helper | Kotlin Multiplatform |
+| `yamv-koin` | `koinMviStore()` / `mviStore {}` DSL | Kotlin Multiplatform |
 | `processor-core` | KSP utilities (DI-agnostic) | JVM |
 | `processor-hilt` | Hilt KSP processor — generates `*Store` + `*FeaturesModule` | JVM |
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build, Test](https://github.com/ktomek/yamv/actions/workflows/ci.yml/badge.svg)](https://github.com/ktomek/yamv/actions/workflows/ci.yml)
 [![JitPack](https://jitpack.io/v/ktomek/yamv.svg)](https://jitpack.io/#ktomek/yamv)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 
 A Kotlin-first **MVI (Model-View-Intent)** framework for Android & Kotlin Multiplatform with compile-time code generation via KSP.
 
@@ -171,5 +171,11 @@ Full documentation: **[ktomek.github.io/yamv](https://ktomek.github.io/yamv)**
 ## License
 
 ```
-MIT License — see LICENSE file
+Copyright 2024 Krzysztof Tomek
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
 ```

--- a/README.md
+++ b/README.md
@@ -11,6 +11,56 @@ A Kotlin-first **MVI (Model-View-Intent)** framework for Android & Kotlin Multip
 - **Multiplatform** — Android (Hilt or Koin) + iOS (Compose Multiplatform + Koin)
 - **Zero boilerplate** — `@AutoState` + `@AutoFeature` generate the retained store and Hilt/Koin modules
 
+## Why YAMV?
+
+Most state management approaches — whether MVVM ViewModels or MVI frameworks with central reducers — tend toward the same problem: logic accumulates in one place. The ViewModel becomes a god object, or the reducer becomes a god function with dozens of cases.
+
+YAMV takes a different approach: **there is no central reducer**.
+
+### Distributed reducers
+
+In a typical MVI framework, a single `reduce()` function handles every action:
+
+```kotlin
+// Typical MVI — one reducer grows with every action
+fun reduce(state: S, action: Action): S = when (action) {
+    is Increment -> state.copy(count = state.count + 1)
+    is SetLoading -> state.copy(loading = true)
+    is SetData -> state.copy(data = action.data)
+    // ... grows linearly
+}
+```
+
+In YAMV, each state transformation is its own `StateOutcome` class — a pure `(S) -> S` function:
+
+```kotlin
+class IncrementOutcome : StateOutcome<CounterState> {
+    override fun reduce(prevState: CounterState) =
+        prevState.copy(count = prevState.count + 1)
+}
+```
+
+Testing is trivial — no coroutines, no Flow, no store setup:
+
+```kotlin
+@Test fun `increment adds one`() {
+    val result = IncrementOutcome().reduce(CounterState(count = 5))
+    assertThat(result.count).isEqualTo(6)
+}
+```
+
+### Separation of "when" from "what"
+
+A **Feature** decides *when* and *which* outcome to emit (the orchestration). An **Outcome** decides *how* state changes (the transformation). Two independent concerns, two independent test targets.
+
+### Forced modularity
+
+Each feature handles one intention type. Each outcome handles one state transition. Adding new behavior means adding a new file — not modifying an existing ViewModel or reducer. Features are injected as a `Set<Feature<S>>`, so they are truly pluggable: add or remove a feature from the DI set without touching any other code.
+
+### Multithreading by convention
+
+Features run on `Dispatchers.Default` (concurrent), reducers apply on `Dispatchers.Main` (serialized) — correct by default. No manual dispatcher management per method. Per-feature and per-state dispatcher customization is available when needed.
+
 ## Quick Start
 
 ### 1. Add JitPack repository

--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ A **Feature** decides *when* and *which* outcome to emit (the orchestration). An
 
 Each feature handles one intention type. Each outcome handles one state transition. Adding new behavior means adding a new file — not modifying an existing ViewModel or reducer. Features are injected as a `Set<Feature<S>>`, so they are truly pluggable: add or remove a feature from the DI set without touching any other code.
 
+### Composable by design
+
+`Set<Feature<S>>` injection means features can be conditionally included via DI configuration — A/B tests, feature flags, build variants — without touching any code. Swap, add, or remove behaviors entirely at the wiring level.
+
 ### Multithreading by convention
 
 Features run on `Dispatchers.Default` (concurrent), reducers apply on `Dispatchers.Main` (serialized) — correct by default. No manual dispatcher management per method. Per-feature and per-state dispatcher customization is available when needed.

--- a/README.md
+++ b/README.md
@@ -82,12 +82,12 @@ class IncrementFeature : TypedFeature<CounterState, CounterIntention.Increment> 
 
 ```kotlin
 @Composable
-fun CounterScreen(vm: CounterStateStore = hiltMviStore()) {
-    val state by vm.state.collectAsStateWithLifecycle()
+fun CounterScreen(store: CounterStateStore = hiltMviStore()) {
+    val state by store.state.collectAsStateWithLifecycle()
 
     Column {
         Text("Count: ${state.count}")
-        Button(onClick = { vm.dispatch(CounterIntention.Increment) }) {
+        Button(onClick = { store.dispatch(CounterIntention.Increment) }) {
             Text("+")
         }
     }

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ sealed class CounterIntention {
 Declare reducers as separate classes — decoupled from features, independently testable:
 
 ```kotlin
-// Reducer — pure (S) -> S, tested without coroutines
-class IncrementReducer : StateOutcome<CounterState> {
+// Outcome — pure (S) -> S, tested without coroutines
+class IncrementOutcome : StateOutcome<CounterState> {
     override fun reduce(prevState: CounterState) =
         prevState.copy(count = prevState.count + 1)
 }
@@ -74,7 +74,7 @@ class IncrementReducer : StateOutcome<CounterState> {
 @AutoFeature
 class IncrementFeature : TypedFeature<CounterState, CounterIntention.Increment> {
     override fun invoke(intentions: Flow<CounterIntention.Increment>): Flow<Outcome<CounterState>> =
-        intentions.map { IncrementReducer() }
+        intentions.map { IncrementOutcome() }
 }
 ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,51 @@
+site_name: YAMV
+site_description: Yet Another MVI Framework — Kotlin-first MVI for Android & KMP
+site_author: Krzysztof Tomek
+site_url: https://ktomek.github.io/yamv
+repo_url: https://github.com/ktomek/yamv
+repo_name: ktomek/yamv
+edit_uri: edit/main/site-docs/
+
+docs_dir: site-docs
+site_dir: site
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: deep purple
+      accent: purple
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: deep purple
+      accent: purple
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - content.code.copy
+    - content.code.annotate
+
+markdown_extensions:
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
+  - admonition
+  - pymdownx.details
+  - attr_list
+
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - Architecture: architecture.md
+  - Features Guide: features.md
+  - Code Generation: code-generation.md
+  - Multiplatform: multiplatform.md
+  - Changelog: changelog.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,7 +36,11 @@ markdown_extensions:
       anchor_linenums: true
   - pymdownx.inlinehilite
   - pymdownx.snippets
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - admonition
   - pymdownx.details
   - attr_list

--- a/site-docs/architecture.md
+++ b/site-docs/architecture.md
@@ -13,7 +13,7 @@ YAMV implements strict unidirectional data flow:
                      │ Intention           │ StateFlow<S>
                      ▼                    │
 ┌─────────────────────────────────────────────────────┐
-│              MviViewModel (generated *Store)         │
+│            MviRetainedStore (generated *Store)        │
 │   delegates to MviRuntime                            │
 └────────────────────┬────────────────────▲────────────┘
                      │                    │
@@ -39,7 +39,7 @@ YAMV implements strict unidirectional data flow:
           ┌──────────┼──────────┐
           ▼          ▼          ▼
      Feature A   Feature B  Feature C
-   (Default dispatcher)
+   (Default dispatcher, or per-feature)
 ```
 
 ## Key Types
@@ -54,6 +54,8 @@ Every feature produces `Outcome<S>` values. There are three kinds:
 | `EffectOutcome<S>` | marker | Emitted on `effects: Flow<EffectOutcome<S>>` |
 | `IntentionOutcome<S>` | has `val intention: Any` | Re-dispatched as a new intention |
 
+Declare outcome subclasses as **standalone classes** — they are decoupled from features and testable in isolation. See [Features Guide](features.md#outcomes-as-separate-classes).
+
 ### Features
 
 Three abstraction levels (choose the simplest one that fits):
@@ -64,23 +66,72 @@ Three abstraction levels (choose the simplest one that fits):
 | `TypedFeature<S, I>` | `(Flow<I>) -> Flow<Outcome<S>>` | Typed; one feature per intention type |
 | `FunctionTypedFeature<S, I>` | `suspend (I) -> Outcome<S>` | Simplest; one outcome per intention |
 
-Use `.wrap()` to convert `TypedFeature` or `FunctionTypedFeature` to `Feature<S>`.
+Use `.wrap()` to convert `TypedFeature` or `FunctionTypedFeature` to `Feature<S>` when wiring manually. With `@AutoFeature` (Hilt) or `mviStore {}` DSL (Koin), wrapping is automatic.
+
 Use `functionTypedFeature<S, I> { }` builder for inline definitions.
 
-## Coroutine Architecture
+## Dispatcher Architecture
+
+`CoroutineDispatcherConfig` controls which dispatcher each part of the pipeline runs on:
 
 ```
-MviRuntime owns CoroutineScope(SupervisorJob() + Main)
+MviRuntime owns CoroutineScope(SupervisorJob() + reducerDispatcher)
 │
-├── launch(Main) ── Reducer collector: scan outcomes → update StateFlow
-├── launch(Main) ── Effect collector: forward EffectOutcomes to effectsFlow
-├── launch(Main) ── IntentionOutcome collector: re-dispatch intentions
+├── launch(reducerDispatcher)    ── Reducer collector: scan outcomes → update StateFlow
+├── launch(reducerDispatcher)    ── Effect collector: forward EffectOutcomes
+├── launch(intentionDispatcher)  ── IntentionOutcome collector: re-dispatch
 │
 └── FeatureRouter initialized with this scope
     │
-    ├── launch(Default) ── Feature A coroutine
-    ├── launch(Default) ── Feature B coroutine
-    └── launch(Default) ── Feature C coroutine
+    ├── launch(featureDispatcher) ── Feature A coroutine
+    ├── launch(featureDispatcher) ── Feature B coroutine
+    └── launch(featureDispatcher) ── Feature C coroutine
+```
+
+Default dispatchers (`DefaultCoroutineDispatcherConfig`):
+
+| Operation | Dispatcher | Rationale |
+|-----------|-----------|-----------|
+| Intention dispatch | `Main` | UI-safe, async launch |
+| Reducers (`scan`) | `Main` | State mutations must be serialized |
+| Effects | `Main` | Observers expect UI thread |
+| Features | `Default` | Non-blocking, concurrent processing |
+
+### Customizing Dispatchers
+
+Override `CoroutineDispatcherConfig` to control dispatcher assignment per intention or feature:
+
+```kotlin
+class CustomDispatcherConfig : CoroutineDispatcherConfig {
+    override fun provideIntentionDispatcher(intention: Any?) = Dispatchers.Main
+    override fun provideReducerDispatcher() = Dispatchers.Main
+    override fun provideFeatureDispatcher(feature: Any) = when (feature) {
+        is NetworkFeature -> Dispatchers.IO
+        else -> Dispatchers.Default
+    }
+}
+```
+
+**Per-feature dispatcher:** Features can implement `HasFeatureDispatcher` to declare their own dispatcher, which takes precedence over `CoroutineDispatcherConfig`:
+
+```kotlin
+class NetworkFeature : TypedFeature<MyState, FetchData>, HasFeatureDispatcher {
+    override val featureDispatcher = Dispatchers.IO
+    // ...
+}
+```
+
+Features with `HasFeatureScope` (via `DefaultFeatureScope`) automatically expose the scope's dispatcher.
+
+**Per-state config (Hilt):** Use the `@MviDispatcherConfig` qualifier to inject a custom config per state type:
+
+```kotlin
+@Module
+@InstallIn(ViewModelComponent::class)
+object MyDispatcherModule {
+    @Provides @MviDispatcherConfig(CounterState::class)
+    fun provide(): CoroutineDispatcherConfig = CustomDispatcherConfig()
+}
 ```
 
 **Key invariant:** `FeatureRouter` uses `CompletableDeferred` to ensure all features are subscribed to the intention `SharedFlow` before the first intention is dispatched. This prevents race conditions at startup.
@@ -88,23 +139,23 @@ MviRuntime owns CoroutineScope(SupervisorJob() + Main)
 ## Lifecycle
 
 ```
-MviViewModel created
+MviRetainedStore created (ViewModel)
   → MviRuntime created (in constructor)
     → FeatureRouter.initialize() called
-      → Feature coroutines launched
+      → Feature coroutines launched (one per feature)
       → All features subscribe to intentionFlow
       → CompletableDeferred completed
   → Ready to dispatch
 
 vm.dispatch(intention)
-  → scope.launch(Main) { intentionRouter.dispatchIntention(intention) }
+  → scope.launch(intentionDispatcher) { intentionRouter.dispatchIntention(intention) }
     → subscribed.await() (returns immediately after init)
     → intentionFlow.emit(intention)
       → Features receive intention, produce Outcomes
       → Outcomes flow to MviRuntime collectors
 
-MviViewModel.onCleared()
+MviRetainedStore.onCleared()
   → store.clear()
     → scope.cancel() (cancels all 3 runtime collectors + all feature coroutines)
-    → FeatureRouter.shutdown() (cancels feature jobs)
+    → FeatureRouter.shutdown() (cancels feature jobs + feature scopes)
 ```

--- a/site-docs/architecture.md
+++ b/site-docs/architecture.md
@@ -5,41 +5,41 @@
 YAMV implements strict unidirectional data flow:
 
 ```
-┌─────────────────────────────────────────────────────┐
-│                   Composable UI                      │
-│   val state by vm.state.collectAsStateWithLifecycle()│
-│   vm.dispatch(CounterIntention.Increment)            │
-└────────────────────┬────────────────────▲────────────┘
-                     │ Intention           │ StateFlow<S>
-                     ▼                    │
-┌─────────────────────────────────────────────────────┐
-│            MviRetainedStore (generated *Store)        │
-│   delegates to MviRuntime                            │
-└────────────────────┬────────────────────▲────────────┘
-                     │                    │
-                     ▼                    │
-┌─────────────────────────────────────────────────────┐
-│                    MviRuntime                        │
-│  ┌──────────────┐  ┌──────────────┐  ┌───────────┐  │
-│  │  Reducers    │  │   Effects    │  │Intentions │  │
-│  │  (Main)      │  │   (Main)     │  │(Main)     │  │
-│  └──────┬───────┘  └──────┬───────┘  └─────┬─────┘  │
-└─────────│─────────────────│────────────────│─────────┘
-          │                 │                │
-          └─────────────────▼────────────────┘
-                     SharedFlow<Outcome<S>>
-                            │
-                            ▼
-┌─────────────────────────────────────────────────────┐
-│                   FeatureRouter                      │
-│   intentionFlow: MutableSharedFlow<Any>              │
-│   outcomeFlow:   MutableSharedFlow<Outcome<S>>       │
-└────────────────────┬────────────────────────────────┘
-                     │ (one coroutine per feature)
-          ┌──────────┼──────────┐
-          ▼          ▼          ▼
-     Feature A   Feature B  Feature C
-   (Default dispatcher, or per-feature)
+┌──────────────────────────────────────────────────────────┐
+│                       Composable UI                      │
+│   val state by store.state.collectAsStateWithLifecycle() │
+│   store.dispatch(CounterIntention.Increment)             │
+└─────────────────────────┬──────────────────▲─────────────┘
+                          │ Intention        │ StateFlow<S>
+                          ▼                  │
+┌──────────────────────────────────────────────────────────┐
+│             MviRetainedStore (generated *Store)           │
+│   delegates to MviRuntime                                │
+└─────────────────────────┬──────────────────▲─────────────┘
+                          │                  │
+                          ▼                  │
+┌──────────────────────────────────────────────────────────┐
+│                       MviRuntime                         │
+│   ┌──────────────┐  ┌──────────────┐  ┌───────────────┐ │
+│   │  Reducers    │  │   Effects    │  │  Intentions   │ │
+│   │  (Main)      │  │   (Main)     │  │  (Main)       │ │
+│   └──────┬───────┘  └──────┬───────┘  └───────┬───────┘ │
+└──────────│─────────────────│──────────────────│──────────┘
+           │                 │                  │
+           └─────────────────▼──────────────────┘
+                      SharedFlow<Outcome<S>>
+                             │
+                             ▼
+┌──────────────────────────────────────────────────────────┐
+│                      FeatureRouter                       │
+│   intentionFlow: MutableSharedFlow<Any>                  │
+│   outcomeFlow:   MutableSharedFlow<Outcome<S>>           │
+└─────────────────────────┬────────────────────────────────┘
+                          │ (one coroutine per feature)
+               ┌──────────┼──────────┐
+               ▼          ▼          ▼
+          Feature A   Feature B  Feature C
+        (Default dispatcher, or per-feature)
 ```
 
 ## Key Types
@@ -150,7 +150,7 @@ MviRetainedStore created (ViewModel)
       → CompletableDeferred completed
   → Ready to dispatch
 
-vm.dispatch(intention)
+store.dispatch(intention)
   → scope.launch(intentionDispatcher) { intentionRouter.dispatchIntention(intention) }
     → subscribed.await() (returns immediately after init)
     → intentionFlow.emit(intention)

--- a/site-docs/architecture.md
+++ b/site-docs/architecture.md
@@ -13,6 +13,7 @@ flowchart LR
     Features(["🧩 Features"])
     Features -->|"Outcome‹S›"| Store
     Store -->|"StateFlow‹S›"| UI
+    Store -.->|"effects"| UI
 ```
 
 **The cycle:** UI dispatches an intention → Store routes it to matching features → features emit outcomes → outcomes update state → UI observes new state.

--- a/site-docs/architecture.md
+++ b/site-docs/architecture.md
@@ -1,0 +1,110 @@
+# Architecture
+
+## MVI Data Flow
+
+YAMV implements strict unidirectional data flow:
+
+```
+┌─────────────────────────────────────────────────────┐
+│                   Composable UI                      │
+│   val state by vm.state.collectAsStateWithLifecycle()│
+│   vm.dispatch(CounterIntention.Increment)            │
+└────────────────────┬────────────────────▲────────────┘
+                     │ Intention           │ StateFlow<S>
+                     ▼                    │
+┌─────────────────────────────────────────────────────┐
+│              MviViewModel (generated *Store)         │
+│   delegates to MviRuntime                            │
+└────────────────────┬────────────────────▲────────────┘
+                     │                    │
+                     ▼                    │
+┌─────────────────────────────────────────────────────┐
+│                    MviRuntime                        │
+│  ┌──────────────┐  ┌──────────────┐  ┌───────────┐  │
+│  │  Reducers    │  │   Effects    │  │Intentions │  │
+│  │  (Main)      │  │   (Main)     │  │(Main)     │  │
+│  └──────┬───────┘  └──────┬───────┘  └─────┬─────┘  │
+└─────────│─────────────────│────────────────│─────────┘
+          │                 │                │
+          └─────────────────▼────────────────┘
+                     SharedFlow<Outcome<S>>
+                            │
+                            ▼
+┌─────────────────────────────────────────────────────┐
+│                   FeatureRouter                      │
+│   intentionFlow: MutableSharedFlow<Any>              │
+│   outcomeFlow:   MutableSharedFlow<Outcome<S>>       │
+└────────────────────┬────────────────────────────────┘
+                     │ (one coroutine per feature)
+          ┌──────────┼──────────┐
+          ▼          ▼          ▼
+     Feature A   Feature B  Feature C
+   (Default dispatcher)
+```
+
+## Key Types
+
+### Outcomes
+
+Every feature produces `Outcome<S>` values. There are three kinds:
+
+| Type | Interface | Effect |
+|------|-----------|--------|
+| `StateOutcome<S>` | `fun interface (S) -> S` | Reduces state via `scan()` |
+| `EffectOutcome<S>` | marker | Emitted on `effects: Flow<EffectOutcome<S>>` |
+| `IntentionOutcome<S>` | has `val intention: Any` | Re-dispatched as a new intention |
+
+### Features
+
+Three abstraction levels (choose the simplest one that fits):
+
+| Type | API | When to use |
+|------|-----|-------------|
+| `Feature.FlowFeature<S>` | `(Flow<Any>) -> Flow<Outcome<S>>` | Low-level; handles multiple intention types |
+| `TypedFeature<S, I>` | `(Flow<I>) -> Flow<Outcome<S>>` | Typed; one feature per intention type |
+| `FunctionTypedFeature<S, I>` | `suspend (I) -> Outcome<S>` | Simplest; one outcome per intention |
+
+Use `.wrap()` to convert `TypedFeature` or `FunctionTypedFeature` to `Feature<S>`.
+Use `functionTypedFeature<S, I> { }` builder for inline definitions.
+
+## Coroutine Architecture
+
+```
+MviRuntime owns CoroutineScope(SupervisorJob() + Main)
+│
+├── launch(Main) ── Reducer collector: scan outcomes → update StateFlow
+├── launch(Main) ── Effect collector: forward EffectOutcomes to effectsFlow
+├── launch(Main) ── IntentionOutcome collector: re-dispatch intentions
+│
+└── FeatureRouter initialized with this scope
+    │
+    ├── launch(Default) ── Feature A coroutine
+    ├── launch(Default) ── Feature B coroutine
+    └── launch(Default) ── Feature C coroutine
+```
+
+**Key invariant:** `FeatureRouter` uses `CompletableDeferred` to ensure all features are subscribed to the intention `SharedFlow` before the first intention is dispatched. This prevents race conditions at startup.
+
+## Lifecycle
+
+```
+MviViewModel created
+  → MviRuntime created (in constructor)
+    → FeatureRouter.initialize() called
+      → Feature coroutines launched
+      → All features subscribe to intentionFlow
+      → CompletableDeferred completed
+  → Ready to dispatch
+
+vm.dispatch(intention)
+  → scope.launch(Main) { intentionRouter.dispatchIntention(intention) }
+    → subscribed.await() (returns immediately after init)
+    → intentionFlow.emit(intention)
+      → Features receive intention, produce Outcomes
+      → Outcomes flow to MviRuntime collectors
+
+MviViewModel.onCleared()
+  → store.clear()
+    → scope.cancel() (cancels all 3 runtime collectors + all feature coroutines)
+    → FeatureRouter.shutdown() (cancels feature jobs)
+```

--- a/site-docs/architecture.md
+++ b/site-docs/architecture.md
@@ -4,67 +4,107 @@
 
 YAMV implements strict unidirectional data flow:
 
+``` mermaid
+flowchart TB
+    subgraph UI ["🖥️ Composable UI"]
+        direction LR
+        dispatch["store.dispatch(Intention)"]
+        observe["store.state.collectAsStateWithLifecycle()"]
+    end
+
+    subgraph Store ["🏪 MviRetainedStore · generated *Store"]
+        delegates["delegates to MviRuntime"]
+    end
+
+    subgraph Runtime ["⚙️ MviRuntime"]
+        direction LR
+        reducers["🔄 Reducers\n`scan() → StateFlow`\n**Main**"]
+        effects["⚡ Effects\n`effectsFlow`\n**Main**"]
+        redispatch["🔁 Re-dispatch\n`IntentionOutcome`\n**Main**"]
+    end
+
+    subgraph Router ["🚦 FeatureRouter"]
+        intentionFlow["intentionFlow\n`SharedFlow‹Any›`"]
+        outcomeFlow["outcomeFlow\n`SharedFlow‹Outcome‹S››`"]
+    end
+
+    subgraph Features ["🧩 Features · one coroutine each"]
+        direction LR
+        fa["Feature A"]
+        fb["Feature B"]
+        fc["Feature C"]
+    end
+
+    dispatch -->|"Intention"| Store
+    Store --> intentionFlow
+    intentionFlow --> fa & fb & fc
+    fa & fb & fc --> outcomeFlow
+    outcomeFlow --> reducers & effects & redispatch
+    reducers -->|"StateFlow‹S›"| observe
+    redispatch -.->|"re-dispatch"| intentionFlow
+
+    style UI fill:#7c4dff,color:#fff,stroke:#7c4dff
+    style Store fill:#651fff,color:#fff,stroke:#651fff
+    style Runtime fill:#6200ea,color:#fff,stroke:#6200ea
+    style Router fill:#aa00ff,color:#fff,stroke:#aa00ff
+    style Features fill:#d500f9,color:#fff,stroke:#d500f9
+
+    style dispatch fill:#b388ff,color:#000,stroke:#7c4dff
+    style observe fill:#b388ff,color:#000,stroke:#7c4dff
+    style delegates fill:#b39ddb,color:#000,stroke:#651fff
+    style reducers fill:#ce93d8,color:#000,stroke:#6200ea
+    style effects fill:#ce93d8,color:#000,stroke:#6200ea
+    style redispatch fill:#ce93d8,color:#000,stroke:#6200ea
+    style intentionFlow fill:#ea80fc,color:#000,stroke:#aa00ff
+    style outcomeFlow fill:#ea80fc,color:#000,stroke:#aa00ff
+    style fa fill:#f3e5f5,color:#000,stroke:#d500f9
+    style fb fill:#f3e5f5,color:#000,stroke:#d500f9
+    style fc fill:#f3e5f5,color:#000,stroke:#d500f9
 ```
-┌──────────────────────────────────────────────────────────┐
-│                       Composable UI                      │
-│   val state by store.state.collectAsStateWithLifecycle() │
-│   store.dispatch(CounterIntention.Increment)             │
-└─────────────────────────┬──────────────────▲─────────────┘
-                          │ Intention        │ StateFlow<S>
-                          ▼                  │
-┌──────────────────────────────────────────────────────────┐
-│             MviRetainedStore (generated *Store)           │
-│   delegates to MviRuntime                                │
-└─────────────────────────┬──────────────────▲─────────────┘
-                          │                  │
-                          ▼                  │
-┌──────────────────────────────────────────────────────────┐
-│                       MviRuntime                         │
-│   ┌──────────────┐  ┌──────────────┐  ┌───────────────┐ │
-│   │  Reducers    │  │   Effects    │  │  Intentions   │ │
-│   │  (Main)      │  │   (Main)     │  │  (Main)       │ │
-│   └──────┬───────┘  └──────┬───────┘  └───────┬───────┘ │
-└──────────│─────────────────│──────────────────│──────────┘
-           │                 │                  │
-           └─────────────────▼──────────────────┘
-                      SharedFlow<Outcome<S>>
-                             │
-                             ▼
-┌──────────────────────────────────────────────────────────┐
-│                      FeatureRouter                       │
-│   intentionFlow: MutableSharedFlow<Any>                  │
-│   outcomeFlow:   MutableSharedFlow<Outcome<S>>           │
-└─────────────────────────┬────────────────────────────────┘
-                          │ (one coroutine per feature)
-               ┌──────────┼──────────┐
-               ▼          ▼          ▼
-          Feature A   Feature B  Feature C
-        (Default dispatcher, or per-feature)
+
+## Outcome Types
+
+``` mermaid
+flowchart LR
+    feature["🧩 Feature"] --> outcome{"Outcome‹S›"}
+    outcome -->|StateOutcome| reducer["🔄 `(S) → S`\nreduces state via scan()"]
+    outcome -->|EffectOutcome| effect["⚡ side effect\nnavigation, toast, etc."]
+    outcome -->|IntentionOutcome| intention["🔁 re-dispatches\nanother intention"]
+
+    style feature fill:#d500f9,color:#fff,stroke:#d500f9
+    style outcome fill:#aa00ff,color:#fff,stroke:#aa00ff
+    style reducer fill:#7c4dff,color:#fff,stroke:#7c4dff
+    style effect fill:#651fff,color:#fff,stroke:#651fff
+    style intention fill:#6200ea,color:#fff,stroke:#6200ea
 ```
-
-## Key Types
-
-### Outcomes
-
-Every feature produces `Outcome<S>` values. There are three kinds:
-
-| Type | Interface | Effect |
-|------|-----------|--------|
-| `StateOutcome<S>` | `fun interface (S) -> S` | Reduces state via `scan()` |
-| `EffectOutcome<S>` | marker | Emitted on `effects: Flow<EffectOutcome<S>>` |
-| `IntentionOutcome<S>` | has `val intention: Any` | Re-dispatched as a new intention |
 
 Declare outcome subclasses as **standalone classes** — they are decoupled from features and testable in isolation. See [Features Guide](features.md#outcomes-as-separate-classes).
 
-### Features
+## Feature Abstraction Levels
 
-Three abstraction levels (choose the simplest one that fits):
+Three levels — choose the simplest one that fits:
 
-| Type | API | When to use |
-|------|-----|-------------|
-| `Feature.FlowFeature<S>` | `(Flow<Any>) -> Flow<Outcome<S>>` | Low-level; handles multiple intention types |
-| `TypedFeature<S, I>` | `(Flow<I>) -> Flow<Outcome<S>>` | Typed; one feature per intention type |
-| `FunctionTypedFeature<S, I>` | `suspend (I) -> Outcome<S>` | Simplest; one outcome per intention |
+``` mermaid
+flowchart LR
+    subgraph simple ["Simplest"]
+        func["**FunctionTypedFeature‹S, I›**\n`suspend (I) → Outcome‹S›`"]
+    end
+    subgraph typed ["Typed streaming"]
+        tf["**TypedFeature‹S, I›**\n`(Flow‹I›) → Flow‹Outcome‹S››`"]
+    end
+    subgraph raw ["Low-level"]
+        ff["**Feature.FlowFeature‹S›**\n`(Flow‹Any›) → Flow‹Outcome‹S››`"]
+    end
+
+    func -.->|".wrap()"| tf -.->|".wrap()"| ff
+
+    style simple fill:#c5cae9,color:#000,stroke:#7c4dff
+    style typed fill:#b39ddb,color:#000,stroke:#7c4dff
+    style raw fill:#ce93d8,color:#000,stroke:#7c4dff
+    style func fill:#e8eaf6,color:#000,stroke:#5c6bc0
+    style tf fill:#ede7f6,color:#000,stroke:#7e57c2
+    style ff fill:#f3e5f5,color:#000,stroke:#ab47bc
+```
 
 Use `.wrap()` to convert `TypedFeature` or `FunctionTypedFeature` to `Feature<S>` when wiring manually. With `@AutoFeature` (Hilt) or `mviStore {}` DSL (Koin), wrapping is automatic.
 
@@ -74,18 +114,38 @@ Use `functionTypedFeature<S, I> { }` builder for inline definitions.
 
 `CoroutineDispatcherConfig` controls which dispatcher each part of the pipeline runs on:
 
-```
-MviRuntime owns CoroutineScope(SupervisorJob() + reducerDispatcher)
-│
-├── launch(reducerDispatcher)    ── Reducer collector: scan outcomes → update StateFlow
-├── launch(reducerDispatcher)    ── Effect collector: forward EffectOutcomes
-├── launch(intentionDispatcher)  ── IntentionOutcome collector: re-dispatch
-│
-└── FeatureRouter initialized with this scope
-    │
-    ├── launch(featureDispatcher) ── Feature A coroutine
-    ├── launch(featureDispatcher) ── Feature B coroutine
-    └── launch(featureDispatcher) ── Feature C coroutine
+``` mermaid
+flowchart TB
+    subgraph scope ["MviRuntime · CoroutineScope(SupervisorJob)"]
+        direction TB
+        subgraph main ["Dispatchers.Main"]
+            r["🔄 Reducer collector\nscan → StateFlow"]
+            e["⚡ Effect collector\nforward EffectOutcomes"]
+            i["🔁 IntentionOutcome collector\nre-dispatch"]
+        end
+    end
+
+    subgraph router ["FeatureRouter"]
+        subgraph feat ["Dispatchers.Default · or per-feature"]
+            direction LR
+            f1["Feature A"]
+            f2["Feature B"]
+            f3["Feature C"]
+        end
+    end
+
+    scope --> router
+
+    style scope fill:#ede7f6,color:#000,stroke:#7c4dff
+    style main fill:#d1c4e9,color:#000,stroke:#651fff
+    style router fill:#f3e5f5,color:#000,stroke:#aa00ff
+    style feat fill:#fce4ec,color:#000,stroke:#d500f9
+    style r fill:#b39ddb,color:#000,stroke:#651fff
+    style e fill:#b39ddb,color:#000,stroke:#651fff
+    style i fill:#b39ddb,color:#000,stroke:#651fff
+    style f1 fill:#f8bbd0,color:#000,stroke:#d500f9
+    style f2 fill:#f8bbd0,color:#000,stroke:#d500f9
+    style f3 fill:#f8bbd0,color:#000,stroke:#d500f9
 ```
 
 Default dispatchers (`DefaultCoroutineDispatcherConfig`):
@@ -137,28 +197,39 @@ object MyDispatcherModule {
 }
 ```
 
-**Key invariant:** `FeatureRouter` uses `CompletableDeferred` to ensure all features are subscribed to the intention `SharedFlow` before the first intention is dispatched. This prevents race conditions at startup.
+!!! info "Subscription safety"
+    `FeatureRouter` uses `CompletableDeferred` to ensure all features are subscribed to the intention `SharedFlow` before the first intention is dispatched. This prevents race conditions at startup.
 
 ## Lifecycle
 
-```
-MviRetainedStore created (ViewModel)
-  → MviRuntime created (in constructor)
-    → FeatureRouter.initialize() called
-      → Feature coroutines launched (one per feature)
-      → All features subscribe to intentionFlow
-      → CompletableDeferred completed
-  → Ready to dispatch
+``` mermaid
+sequenceDiagram
+    participant UI as 🖥️ UI
+    participant Store as 🏪 MviRetainedStore
+    participant Runtime as ⚙️ MviRuntime
+    participant Router as 🚦 FeatureRouter
+    participant F as 🧩 Features
 
-store.dispatch(intention)
-  → scope.launch(intentionDispatcher) { intentionRouter.dispatchIntention(intention) }
-    → subscribed.await() (returns immediately after init)
-    → intentionFlow.emit(intention)
-      → Features receive intention, produce Outcomes
-      → Outcomes flow to MviRuntime collectors
+    Note over Store,Runtime: Construction
+    Store->>Runtime: create MviRuntime
+    Runtime->>Router: initialize(scope, config)
+    Router->>F: launch coroutine per feature
+    F-->>Router: subscribe to intentionFlow
+    Note over Router: CompletableDeferred ✅
 
-MviRetainedStore.onCleared()
-  → store.clear()
-    → scope.cancel() (cancels all 3 runtime collectors + all feature coroutines)
-    → FeatureRouter.shutdown() (cancels feature jobs + feature scopes)
+    Note over UI,F: Dispatch
+    UI->>Store: dispatch(intention)
+    Store->>Runtime: scope.launch { dispatchIntention }
+    Runtime->>Router: intentionFlow.emit(intention)
+    Router->>F: intention broadcast
+    F-->>Router: Outcome‹S›
+    Router-->>Runtime: outcomeFlow
+    Runtime-->>Runtime: scan → StateFlow
+    Runtime-->>UI: StateFlow‹S› updated
+
+    Note over UI,F: Cleanup
+    UI->>Store: onCleared()
+    Store->>Runtime: clear()
+    Runtime->>Router: shutdown()
+    Router->>F: cancel all jobs + scopes
 ```

--- a/site-docs/architecture.md
+++ b/site-docs/architecture.md
@@ -5,106 +5,45 @@
 YAMV implements strict unidirectional data flow:
 
 ``` mermaid
-flowchart TB
-    subgraph UI ["🖥️ Composable UI"]
-        direction LR
-        dispatch["store.dispatch(Intention)"]
-        observe["store.state.collectAsStateWithLifecycle()"]
-    end
-
-    subgraph Store ["🏪 MviRetainedStore · generated *Store"]
-        delegates["delegates to MviRuntime"]
-    end
-
-    subgraph Runtime ["⚙️ MviRuntime"]
-        direction LR
-        reducers["🔄 Reducers\n`scan() → StateFlow`\n**Main**"]
-        effects["⚡ Effects\n`effectsFlow`\n**Main**"]
-        redispatch["🔁 Re-dispatch\n`IntentionOutcome`\n**Main**"]
-    end
-
-    subgraph Router ["🚦 FeatureRouter"]
-        intentionFlow["intentionFlow\n`SharedFlow‹Any›`"]
-        outcomeFlow["outcomeFlow\n`SharedFlow‹Outcome‹S››`"]
-    end
-
-    subgraph Features ["🧩 Features · one coroutine each"]
-        direction LR
-        fa["Feature A"]
-        fb["Feature B"]
-        fc["Feature C"]
-    end
-
-    dispatch -->|"Intention"| Store
-    Store --> intentionFlow
-    intentionFlow --> fa & fb & fc
-    fa & fb & fc --> outcomeFlow
-    outcomeFlow --> reducers & effects & redispatch
-    reducers -->|"StateFlow‹S›"| observe
-    redispatch -.->|"re-dispatch"| intentionFlow
-
-    style UI fill:#7c4dff,color:#fff,stroke:#7c4dff
-    style Store fill:#651fff,color:#fff,stroke:#651fff
-    style Runtime fill:#6200ea,color:#fff,stroke:#6200ea
-    style Router fill:#aa00ff,color:#fff,stroke:#aa00ff
-    style Features fill:#d500f9,color:#fff,stroke:#d500f9
-
-    style dispatch fill:#b388ff,color:#000,stroke:#7c4dff
-    style observe fill:#b388ff,color:#000,stroke:#7c4dff
-    style delegates fill:#b39ddb,color:#000,stroke:#651fff
-    style reducers fill:#ce93d8,color:#000,stroke:#6200ea
-    style effects fill:#ce93d8,color:#000,stroke:#6200ea
-    style redispatch fill:#ce93d8,color:#000,stroke:#6200ea
-    style intentionFlow fill:#ea80fc,color:#000,stroke:#aa00ff
-    style outcomeFlow fill:#ea80fc,color:#000,stroke:#aa00ff
-    style fa fill:#f3e5f5,color:#000,stroke:#d500f9
-    style fb fill:#f3e5f5,color:#000,stroke:#d500f9
-    style fc fill:#f3e5f5,color:#000,stroke:#d500f9
+flowchart LR
+    UI(["🖥️ UI"])
+    UI -->|"dispatch(Intention)"| Store
+    Store(["🏪 Store"])
+    Store -->|"routes to"| Features
+    Features(["🧩 Features"])
+    Features -->|"Outcome‹S›"| Store
+    Store -->|"StateFlow‹S›"| UI
 ```
+
+**The cycle:** UI dispatches an intention → Store routes it to matching features → features emit outcomes → outcomes update state → UI observes new state.
+
+Outcomes come in three kinds:
+
+- **`StateOutcome`** — pure `(S) → S` reducer, applied via `scan()`
+- **`EffectOutcome`** — side effect (navigation, toast, analytics)
+- **`IntentionOutcome`** — re-dispatches another intention back into the cycle
 
 ## Outcome Types
 
 ``` mermaid
 flowchart LR
-    feature["🧩 Feature"] --> outcome{"Outcome‹S›"}
-    outcome -->|StateOutcome| reducer["🔄 `(S) → S`\nreduces state via scan()"]
-    outcome -->|EffectOutcome| effect["⚡ side effect\nnavigation, toast, etc."]
-    outcome -->|IntentionOutcome| intention["🔁 re-dispatches\nanother intention"]
-
-    style feature fill:#d500f9,color:#fff,stroke:#d500f9
-    style outcome fill:#aa00ff,color:#fff,stroke:#aa00ff
-    style reducer fill:#7c4dff,color:#fff,stroke:#7c4dff
-    style effect fill:#651fff,color:#fff,stroke:#651fff
-    style intention fill:#6200ea,color:#fff,stroke:#6200ea
+    feature(["🧩 Feature"]) --> outcome{"Outcome‹S›"}
+    outcome -->|StateOutcome| reducer["🔄 reduces state\n`(S) → S`"]
+    outcome -->|EffectOutcome| effect["⚡ side effect"]
+    outcome -->|IntentionOutcome| intention["🔁 re-dispatches\nintention"]
 ```
 
 Declare outcome subclasses as **standalone classes** — they are decoupled from features and testable in isolation. See [Features Guide](features.md#outcomes-as-separate-classes).
 
 ## Feature Abstraction Levels
 
-Three levels — choose the simplest one that fits:
+Three abstraction levels (choose the simplest one that fits):
 
-``` mermaid
-flowchart LR
-    subgraph simple ["Simplest"]
-        func["**FunctionTypedFeature‹S, I›**\n`suspend (I) → Outcome‹S›`"]
-    end
-    subgraph typed ["Typed streaming"]
-        tf["**TypedFeature‹S, I›**\n`(Flow‹I›) → Flow‹Outcome‹S››`"]
-    end
-    subgraph raw ["Low-level"]
-        ff["**Feature.FlowFeature‹S›**\n`(Flow‹Any›) → Flow‹Outcome‹S››`"]
-    end
-
-    func -.->|".wrap()"| tf -.->|".wrap()"| ff
-
-    style simple fill:#c5cae9,color:#000,stroke:#7c4dff
-    style typed fill:#b39ddb,color:#000,stroke:#7c4dff
-    style raw fill:#ce93d8,color:#000,stroke:#7c4dff
-    style func fill:#e8eaf6,color:#000,stroke:#5c6bc0
-    style tf fill:#ede7f6,color:#000,stroke:#7e57c2
-    style ff fill:#f3e5f5,color:#000,stroke:#ab47bc
-```
+| Type | API | When to use |
+|------|-----|-------------|
+| `Feature.FlowFeature<S>` | `(Flow<Any>) -> Flow<Outcome<S>>` | Low-level; handles multiple intention types |
+| `TypedFeature<S, I>` | `(Flow<I>) -> Flow<Outcome<S>>` | Typed; one feature per intention type |
+| `FunctionTypedFeature<S, I>` | `suspend (I) -> Outcome<S>` | Simplest; one outcome per intention |
 
 Use `.wrap()` to convert `TypedFeature` or `FunctionTypedFeature` to `Feature<S>` when wiring manually. With `@AutoFeature` (Hilt) or `mviStore {}` DSL (Koin), wrapping is automatic.
 
@@ -114,38 +53,18 @@ Use `functionTypedFeature<S, I> { }` builder for inline definitions.
 
 `CoroutineDispatcherConfig` controls which dispatcher each part of the pipeline runs on:
 
-``` mermaid
-flowchart TB
-    subgraph scope ["MviRuntime · CoroutineScope(SupervisorJob)"]
-        direction TB
-        subgraph main ["Dispatchers.Main"]
-            r["🔄 Reducer collector\nscan → StateFlow"]
-            e["⚡ Effect collector\nforward EffectOutcomes"]
-            i["🔁 IntentionOutcome collector\nre-dispatch"]
-        end
-    end
-
-    subgraph router ["FeatureRouter"]
-        subgraph feat ["Dispatchers.Default · or per-feature"]
-            direction LR
-            f1["Feature A"]
-            f2["Feature B"]
-            f3["Feature C"]
-        end
-    end
-
-    scope --> router
-
-    style scope fill:#ede7f6,color:#000,stroke:#7c4dff
-    style main fill:#d1c4e9,color:#000,stroke:#651fff
-    style router fill:#f3e5f5,color:#000,stroke:#aa00ff
-    style feat fill:#fce4ec,color:#000,stroke:#d500f9
-    style r fill:#b39ddb,color:#000,stroke:#651fff
-    style e fill:#b39ddb,color:#000,stroke:#651fff
-    style i fill:#b39ddb,color:#000,stroke:#651fff
-    style f1 fill:#f8bbd0,color:#000,stroke:#d500f9
-    style f2 fill:#f8bbd0,color:#000,stroke:#d500f9
-    style f3 fill:#f8bbd0,color:#000,stroke:#d500f9
+```
+MviRuntime owns CoroutineScope(SupervisorJob() + reducerDispatcher)
+│
+├── launch(reducerDispatcher)    ── Reducer collector: scan outcomes → update StateFlow
+├── launch(reducerDispatcher)    ── Effect collector: forward EffectOutcomes
+├── launch(intentionDispatcher)  ── IntentionOutcome collector: re-dispatch
+│
+└── FeatureRouter initialized with this scope
+    │
+    ├── launch(featureDispatcher) ── Feature A coroutine
+    ├── launch(featureDispatcher) ── Feature B coroutine
+    └── launch(featureDispatcher) ── Feature C coroutine
 ```
 
 Default dispatchers (`DefaultCoroutineDispatcherConfig`):

--- a/site-docs/architecture.md
+++ b/site-docs/architecture.md
@@ -103,11 +103,14 @@ Override `CoroutineDispatcherConfig` to control dispatcher assignment per intent
 
 ```kotlin
 class CustomDispatcherConfig : CoroutineDispatcherConfig {
+    // Single-threaded dispatcher for sequential feature processing
+    private val singleThread = Dispatchers.Default.limitedParallelism(1)
+
     override fun provideIntentionDispatcher(intention: Any?) = Dispatchers.Main
     override fun provideReducerDispatcher() = Dispatchers.Main
     override fun provideFeatureDispatcher(feature: Any) = when (feature) {
         is NetworkFeature -> Dispatchers.IO
-        else -> Dispatchers.Default
+        else -> singleThread
     }
 }
 ```

--- a/site-docs/changelog.md
+++ b/site-docs/changelog.md
@@ -1,0 +1,17 @@
+# Changelog
+
+## [0.1.0] — Initial Release
+
+### Added
+- `MviRuntime` — core MVI runtime with coroutine-based state management
+- `MviStore` — interface for state store (state + effects + dispatch)
+- `FeatureRouter` — intention routing with subscription ordering guarantee
+- `Feature` sealed interface: `FlowFeature`, `FlowUnitFeature`
+- `TypedFeature` — typed intention flow transformer
+- `FunctionTypedFeature` — single-intention suspend handler with concurrent processing
+- `MviViewModel` — Android/iOS ViewModel base class
+- `@AutoState` / `@AutoFeature` — KSP annotations for compile-time code generation
+- `processor-hilt` — Hilt KSP processor generating `*Store` and `*FeaturesModule`
+- `yamv-hilt` — `hiltMviStore()` Compose helper
+- `yamv-koin` — `koinMviStore()` multiplatform Compose helper
+- iOS support via Compose Multiplatform + Koin

--- a/site-docs/code-generation.md
+++ b/site-docs/code-generation.md
@@ -1,10 +1,10 @@
 # Code Generation
 
-YAMV uses [KSP (Kotlin Symbol Processing)](https://github.com/google/ksp) to generate boilerplate at compile time. You write the annotations; YAMV generates the ViewModel and DI wiring.
+YAMV uses [KSP (Kotlin Symbol Processing)](https://github.com/google/ksp) to generate boilerplate at compile time. You write the annotations; YAMV generates the retained store and DI wiring.
 
 ## @AutoState
 
-Annotate a `State` subclass to generate a `*Store` ViewModel:
+Annotate a `State` subclass to generate a `*Store` retained store:
 
 ```kotlin
 @AutoState
@@ -16,11 +16,15 @@ data class CounterState(val count: Int = 0) : State
 @HiltViewModel
 class CounterStateStore @Inject constructor(
     features: Set<@JvmSuppressWildcards Feature<CounterState>>,
-    stateHandle: StateHandle,
-) : MviViewModel<CounterState, Any>() {
+    @MviDispatcherConfig(CounterState::class)
+    optionalDispatcherConfig: Optional<CoroutineDispatcherConfig>,
+) : MviRetainedStore<CounterState, Any>() {
+    override val dispatcherConfig: CoroutineDispatcherConfig =
+        optionalDispatcherConfig.orElseGet { DefaultCoroutineDispatcherConfig() }
     override val store: MviStore<CounterState, Any> = MviRuntime(
         features = features,
         defaultState = CounterState(),
+        dispatcherConfig = dispatcherConfig,
     )
 }
 ```
@@ -41,20 +45,24 @@ class IncrementFeature : TypedFeature<CounterState, CounterIntention.Increment> 
 @Module
 @InstallIn(ViewModelComponent::class)
 interface CounterStateFeaturesModule {
-    @Binds
-    @IntoSet
-    @ViewModelScoped
+    @Binds @IntoSet @ViewModelScoped
     fun bindIncrementFeature(feature: IncrementFeature): Feature<CounterState>
 
+    @BindsOptionalOf @MviDispatcherConfig(CounterState::class)
+    fun bindOptionalDispatcherConfig(): CoroutineDispatcherConfig
+
     companion object {
-        @Provides
-        @IntoSet
-        @ViewModelScoped
-        fun provideIncrementFeatureWrapped(feature: IncrementFeature): Feature<CounterState> =
-            feature.wrap()
+        @Provides @ElementsIntoSet @ViewModelScoped
+        fun provideDefaults(): Set<Feature<CounterState>> = emptySet()
+
+        // FunctionTypedFeature classes get .wrap() in companion:
+        @Provides @IntoSet @ViewModelScoped
+        fun provideDecreaseFeature(it: DecreaseFeature): Feature<CounterState> = it.wrap()
     }
 }
 ```
+
+`@Binds` (abstract) methods go in the interface body; `@Provides` + `.wrap()` methods go in the companion object (Dagger constraint).
 
 ## Using @AutoFeature on Properties
 
@@ -64,7 +72,7 @@ If your feature is a lambda or builder result, annotate the property:
 object CounterFeatures {
     @AutoFeature
     val incrementFeature = functionTypedFeature<CounterState, CounterIntention.Increment> { _ ->
-        StateOutcome { state -> state.copy(count = state.count + 1) }
+        IncrementReducer()
     }
 }
 ```
@@ -78,14 +86,23 @@ object CounterFeatures {
 
 ## Without Code Generation
 
-If you prefer manual wiring (or use Koin without KSP), extend `MviViewModel` directly:
+If you prefer manual wiring (or use Koin without KSP), extend `MviRetainedStore` directly and call `.wrap()` on typed features:
 
 ```kotlin
 class CounterViewModel(features: Set<Feature<CounterState>>)
-    : MviViewModel<CounterState, Any>() {
+    : MviRetainedStore<CounterState, Any>() {
     override val store = MviRuntime(
         features = features,
         defaultState = CounterState(),
     )
 }
+
+// Manual wiring — .wrap() required for TypedFeature / FunctionTypedFeature
+val store = MviRuntime(
+    features = setOf(
+        IncrementFeature().wrap(),
+        DecrementFeature().wrap(),
+    ),
+    defaultState = CounterState(),
+)
 ```

--- a/site-docs/code-generation.md
+++ b/site-docs/code-generation.md
@@ -1,0 +1,91 @@
+# Code Generation
+
+YAMV uses [KSP (Kotlin Symbol Processing)](https://github.com/google/ksp) to generate boilerplate at compile time. You write the annotations; YAMV generates the ViewModel and DI wiring.
+
+## @AutoState
+
+Annotate a `State` subclass to generate a `*Store` ViewModel:
+
+```kotlin
+@AutoState
+data class CounterState(val count: Int = 0) : State
+```
+
+**Generated** `CounterStateStore.kt`:
+```kotlin
+@HiltViewModel
+class CounterStateStore @Inject constructor(
+    features: Set<@JvmSuppressWildcards Feature<CounterState>>,
+    stateHandle: StateHandle,
+) : MviViewModel<CounterState, Any>() {
+    override val store: MviStore<CounterState, Any> = MviRuntime(
+        features = features,
+        defaultState = CounterState(),
+    )
+}
+```
+
+The `defaultState` is inferred from the primary constructor's default values.
+
+## @AutoFeature
+
+Annotate a `Feature` implementation to include it in the Hilt multibinding set:
+
+```kotlin
+@AutoFeature
+class IncrementFeature : TypedFeature<CounterState, CounterIntention.Increment> { ... }
+```
+
+**Generated** inside `CounterStateFeaturesModule.kt`:
+```kotlin
+@Module
+@InstallIn(ViewModelComponent::class)
+interface CounterStateFeaturesModule {
+    @Binds
+    @IntoSet
+    @ViewModelScoped
+    fun bindIncrementFeature(feature: IncrementFeature): Feature<CounterState>
+
+    companion object {
+        @Provides
+        @IntoSet
+        @ViewModelScoped
+        fun provideIncrementFeatureWrapped(feature: IncrementFeature): Feature<CounterState> =
+            feature.wrap()
+    }
+}
+```
+
+## Using @AutoFeature on Properties
+
+If your feature is a lambda or builder result, annotate the property:
+
+```kotlin
+object CounterFeatures {
+    @AutoFeature
+    val incrementFeature = functionTypedFeature<CounterState, CounterIntention.Increment> { _ ->
+        StateOutcome { state -> state.copy(count = state.count + 1) }
+    }
+}
+```
+
+## Processor Modules
+
+| Module | Annotation | Output |
+|--------|-----------|--------|
+| `processor-hilt` | `@AutoState` | `{Name}Store` (`@HiltViewModel`) |
+| `processor-hilt` | `@AutoFeature` | `{Name}FeaturesModule` (Hilt `@Module`) |
+
+## Without Code Generation
+
+If you prefer manual wiring (or use Koin without KSP), extend `MviViewModel` directly:
+
+```kotlin
+class CounterViewModel(features: Set<Feature<CounterState>>)
+    : MviViewModel<CounterState, Any>() {
+    override val store = MviRuntime(
+        features = features,
+        defaultState = CounterState(),
+    )
+}
+```

--- a/site-docs/code-generation.md
+++ b/site-docs/code-generation.md
@@ -51,11 +51,12 @@ interface CounterStateFeaturesModule {
     @BindsOptionalOf @MviDispatcherConfig(CounterState::class)
     fun bindOptionalDispatcherConfig(): CoroutineDispatcherConfig
 
-    companion object {
-        @Provides @ElementsIntoSet @ViewModelScoped
-        fun provideDefaults(): Set<Feature<CounterState>> = emptySet()
+    // @Multibinds declares the empty set so Dagger doesn't fail when no features are bound
+    @Multibinds
+    fun featureSet(): Set<Feature<CounterState>>
 
-        // FunctionTypedFeature classes get .wrap() in companion:
+    companion object {
+        // FunctionTypedFeature classes need .wrap() — goes in companion:
         @Provides @IntoSet @ViewModelScoped
         fun provideDecreaseFeature(it: DecreaseFeature): Feature<CounterState> = it.wrap()
     }
@@ -72,7 +73,7 @@ If your feature is a lambda or builder result, annotate the property:
 object CounterFeatures {
     @AutoFeature
     val incrementFeature = functionTypedFeature<CounterState, CounterIntention.Increment> { _ ->
-        IncrementReducer()
+        IncrementOutcome()
     }
 }
 ```

--- a/site-docs/features.md
+++ b/site-docs/features.md
@@ -4,33 +4,33 @@ A **Feature** transforms a stream of intentions into a stream of outcomes. Each 
 
 ## Outcomes as Separate Classes
 
-Declare `StateOutcome` reducers as standalone classes or objects. This decouples state transformations from features, making them independently testable with simple unit tests (no Flow, no coroutines):
+Declare `StateOutcome` subclasses as standalone classes. This decouples state transformations from features, making them independently testable with simple unit tests (no Flow, no coroutines):
 
 ```kotlin
-// Reducer — pure function, tested in isolation
-class IncrementReducer : StateOutcome<CounterState> {
+// Outcome — pure function, tested in isolation
+class IncrementOutcome : StateOutcome<CounterState> {
     override fun reduce(prevState: CounterState) =
         prevState.copy(count = prevState.count + 1)
 }
 
-class DecrementReducer : StateOutcome<CounterState> {
+class DecrementOutcome : StateOutcome<CounterState> {
     override fun reduce(prevState: CounterState) =
         prevState.copy(count = prevState.count - 1)
 }
 
 // Test — simple, no coroutines needed
 @Test
-fun `IncrementReducer increments count`() {
-    val result = IncrementReducer().reduce(CounterState(count = 5))
+fun `IncrementOutcome increments count`() {
+    val result = IncrementOutcome().reduce(CounterState(count = 5))
     assertThat(result.count).isEqualTo(6)
 }
 ```
 
-Features then reference these reducers:
+Features then reference these outcomes:
 
 ```kotlin
 val incrementFeature = functionTypedFeature<CounterState, CounterIntention.Increment> { _ ->
-    IncrementReducer()
+    IncrementOutcome()
 }
 ```
 
@@ -42,7 +42,7 @@ For one-shot operations (no streaming, no background work):
 
 ```kotlin
 val incrementFeature = functionTypedFeature<CounterState, CounterIntention.Increment> { _ ->
-    IncrementReducer()
+    IncrementOutcome()
 }
 ```
 
@@ -51,7 +51,7 @@ Or as a class:
 ```kotlin
 class IncrementFeature : FunctionTypedFeature<CounterState, CounterIntention.Increment> {
     override suspend fun invoke(intention: CounterIntention.Increment): Outcome<CounterState> =
-        IncrementReducer()
+        IncrementOutcome()
 }
 ```
 
@@ -85,48 +85,23 @@ class FetchDataFeature(
     override fun invoke(
         intentions: Flow<AppIntention.Fetch>
     ): Flow<Outcome<AppState>> =
-        intentions.flatMapMerge { intention ->
-            flow {
-                emit(LoadingReducer())
-                val data = repository.fetch(intention.id)
-                emit(DataLoadedReducer(data))
+        intentions
+            .flatMapMerge { intention ->
+                flow { emit(repository.fetch(intention.id)) }
+                    .map(::DataLoadedOutcome)
+                    .onStart { emit(LoadingOutcome()) }
             }
-        }
 }
 ```
 
 Use `flatMapMerge` for concurrent processing, `flatMapLatest` to cancel previous work on new intention, or `map` for simple 1:1 transforms:
 
 ```kotlin
-// Simple 1:1 transform — no need for channelFlow
 class IncrementFeature : TypedFeature<CounterState, CounterIntention.Increment> {
     override fun invoke(
         intentions: Flow<CounterIntention.Increment>
     ): Flow<Outcome<CounterState>> =
-        intentions.map { IncrementReducer() }
-}
-```
-
-### When to use `channelFlow`
-
-Reserve `channelFlow { }` for features that need to **launch independent coroutines** — timers, polling, WebSocket listeners — where the work isn't driven by the intention stream:
-
-```kotlin
-class AutoIncrementFeature : TypedFeature<CounterState, CounterIntention.StartAuto> {
-    override fun invoke(
-        intentions: Flow<CounterIntention.StartAuto>
-    ): Flow<Outcome<CounterState>> = channelFlow {
-        var timerJob: Job? = null
-        intentions.collect { _ ->
-            timerJob?.cancel()
-            timerJob = launch {
-                while (isActive) {
-                    delay(1_000)
-                    send(IncrementReducer())
-                }
-            }
-        }
-    }
+        intentions.map { IncrementOutcome() }
 }
 ```
 
@@ -145,7 +120,7 @@ class LoggingFeature : Feature.FlowUnitFeature<AppState> {
 
 ## Combining Outcomes
 
-A single feature can emit multiple outcome types using `flatMapMerge` or `flatMapConcat`:
+A single feature can emit multiple outcome types using flow operators. Keep the chain simple — one operator per line, extract to a function if it grows:
 
 ```kotlin
 class LoginFeature(
@@ -154,19 +129,13 @@ class LoginFeature(
     override fun invoke(
         intentions: Flow<AppIntention.Login>
     ): Flow<Outcome<AppState>> =
-        intentions.flatMapMerge { intention ->
-            flow {
-                emit(LoginLoadingReducer())
-                try {
-                    val user = auth.login(intention.email, intention.password)
-                    emit(LoginSuccessReducer(user))
-                    emit(object : IntentionOutcome<AppState> {
-                        override val intention = AppIntention.LoadDashboard
-                    })
-                } catch (e: AuthException) {
-                    emit(LoginErrorReducer(e.message))
-                }
-            }
-        }
+        intentions
+            .flatMapMerge { intention -> login(intention) }
+
+    private fun login(intention: AppIntention.Login): Flow<Outcome<AppState>> =
+        flow { emit(auth.login(intention.email, intention.password)) }
+            .map<User, Outcome<AppState>> { user -> LoginSuccessOutcome(user) }
+            .onStart { emit(LoginLoadingOutcome()) }
+            .catch { e -> emit(LoginErrorOutcome(e.message)) }
 }
 ```

--- a/site-docs/features.md
+++ b/site-docs/features.md
@@ -2,13 +2,47 @@
 
 A **Feature** transforms a stream of intentions into a stream of outcomes. Each feature is responsible for one piece of logic.
 
+## Outcomes as Separate Classes
+
+Declare `StateOutcome` reducers as standalone classes or objects. This decouples state transformations from features, making them independently testable with simple unit tests (no Flow, no coroutines):
+
+```kotlin
+// Reducer — pure function, tested in isolation
+class IncrementReducer : StateOutcome<CounterState> {
+    override fun reduce(prevState: CounterState) =
+        prevState.copy(count = prevState.count + 1)
+}
+
+class DecrementReducer : StateOutcome<CounterState> {
+    override fun reduce(prevState: CounterState) =
+        prevState.copy(count = prevState.count - 1)
+}
+
+// Test — simple, no coroutines needed
+@Test
+fun `IncrementReducer increments count`() {
+    val result = IncrementReducer().reduce(CounterState(count = 5))
+    assertThat(result.count).isEqualTo(6)
+}
+```
+
+Features then reference these reducers:
+
+```kotlin
+val incrementFeature = functionTypedFeature<CounterState, CounterIntention.Increment> { _ ->
+    IncrementReducer()
+}
+```
+
+This separation applies to all outcome types — `EffectOutcome` and `IntentionOutcome` subclasses benefit from the same pattern.
+
 ## FunctionTypedFeature — simplest
 
 For one-shot operations (no streaming, no background work):
 
 ```kotlin
 val incrementFeature = functionTypedFeature<CounterState, CounterIntention.Increment> { _ ->
-    StateOutcome { state -> state.copy(count = state.count + 1) }
+    IncrementReducer()
 }
 ```
 
@@ -17,20 +51,32 @@ Or as a class:
 ```kotlin
 class IncrementFeature : FunctionTypedFeature<CounterState, CounterIntention.Increment> {
     override suspend fun invoke(intention: CounterIntention.Increment): Outcome<CounterState> =
-        StateOutcome { state -> state.copy(count = state.count + 1) }
+        IncrementReducer()
 }
-```
-
-Use `.wrap()` to convert to `Feature<S>`:
-```kotlin
-IncrementFeature().wrap()
 ```
 
 > **Note:** Multiple concurrent intentions are processed concurrently. If your `invoke` does async work (network, DB), each intention gets its own coroutine automatically.
 
+### Using `.wrap()`
+
+`FunctionTypedFeature` and `TypedFeature` must be converted to `Feature<S>` before passing to `MviRuntime`. If you're **not** using Hilt code generation (`@AutoFeature`) or the Koin `mviStore {}` DSL, call `.wrap()` manually:
+
+```kotlin
+val runtime = MviRuntime(
+    features = setOf(
+        IncrementFeature().wrap(),
+        DecrementFeature().wrap(),
+    ),
+    defaultState = CounterState(),
+)
+```
+
+With **Hilt** (`@AutoFeature`), the generated module calls `.wrap()` for you.
+With **Koin** `mviStore {}` DSL, features are wrapped automatically via `FeatureRegistrar`.
+
 ## TypedFeature — typed streaming
 
-For features that transform a stream of intentions:
+For features that transform a stream of intentions. Operate directly on the `intentions` flow — use standard flow operators (`map`, `flatMapLatest`, `flatMapMerge`, etc.) to transform intentions into outcomes:
 
 ```kotlin
 class FetchDataFeature(
@@ -38,27 +84,32 @@ class FetchDataFeature(
 ) : TypedFeature<AppState, AppIntention.Fetch> {
     override fun invoke(
         intentions: Flow<AppIntention.Fetch>
-    ): Flow<Outcome<AppState>> = channelFlow {
-        intentions.collect { intention ->
-            try {
-                val data = repository.fetch(intention.id)  // suspend call
-                send(StateOutcome { state -> state.copy(data = data) })
-            } catch (e: Exception) {
-                send(StateOutcome { state -> state.copy(error = e.message) })
+    ): Flow<Outcome<AppState>> =
+        intentions.flatMapMerge { intention ->
+            flow {
+                emit(LoadingReducer())
+                val data = repository.fetch(intention.id)
+                emit(DataLoadedReducer(data))
             }
         }
-    }
 }
 ```
 
-Use `.wrap()` to convert:
+Use `flatMapMerge` for concurrent processing, `flatMapLatest` to cancel previous work on new intention, or `map` for simple 1:1 transforms:
+
 ```kotlin
-FetchDataFeature(repository).wrap()
+// Simple 1:1 transform — no need for channelFlow
+class IncrementFeature : TypedFeature<CounterState, CounterIntention.Increment> {
+    override fun invoke(
+        intentions: Flow<CounterIntention.Increment>
+    ): Flow<Outcome<CounterState>> =
+        intentions.map { IncrementReducer() }
+}
 ```
 
-## TypedFeature with background work
+### When to use `channelFlow`
 
-Use `channelFlow { }` when you need to launch background coroutines (timers, polling):
+Reserve `channelFlow { }` for features that need to **launch independent coroutines** — timers, polling, WebSocket listeners — where the work isn't driven by the intention stream:
 
 ```kotlin
 class AutoIncrementFeature : TypedFeature<CounterState, CounterIntention.StartAuto> {
@@ -71,15 +122,13 @@ class AutoIncrementFeature : TypedFeature<CounterState, CounterIntention.StartAu
             timerJob = launch {
                 while (isActive) {
                     delay(1_000)
-                    send(StateOutcome { state -> state.copy(count = state.count + 1) })
+                    send(IncrementReducer())
                 }
             }
         }
     }
 }
 ```
-
-The `channelFlow` block's `this` is a `ProducerScope` (a `CoroutineScope` + `send()`). Any `launch { }` inside is a child of the feature's coroutine — cancelled automatically when the ViewModel is cleared.
 
 ## FlowFeature — low-level
 
@@ -96,7 +145,7 @@ class LoggingFeature : Feature.FlowUnitFeature<AppState> {
 
 ## Combining Outcomes
 
-A single feature can emit multiple outcome types:
+A single feature can emit multiple outcome types using `flatMapMerge` or `flatMapConcat`:
 
 ```kotlin
 class LoginFeature(
@@ -104,19 +153,20 @@ class LoginFeature(
 ) : TypedFeature<AppState, AppIntention.Login> {
     override fun invoke(
         intentions: Flow<AppIntention.Login>
-    ): Flow<Outcome<AppState>> = channelFlow {
-        intentions.collect { intention ->
-            try {
-                val user = auth.login(intention.email, intention.password)
-                send(StateOutcome { state -> state.copy(user = user, isLoading = false) })
-                send(object : IntentionOutcome<AppState> {
-                    override val intention = AppIntention.LoadDashboard
-                })
-            } catch (e: AuthException) {
-                send(StateOutcome { state -> state.copy(error = e.message, isLoading = false) })
-                send(object : EffectOutcome<AppState> {})  // trigger snackbar, etc.
+    ): Flow<Outcome<AppState>> =
+        intentions.flatMapMerge { intention ->
+            flow {
+                emit(LoginLoadingReducer())
+                try {
+                    val user = auth.login(intention.email, intention.password)
+                    emit(LoginSuccessReducer(user))
+                    emit(object : IntentionOutcome<AppState> {
+                        override val intention = AppIntention.LoadDashboard
+                    })
+                } catch (e: AuthException) {
+                    emit(LoginErrorReducer(e.message))
+                }
             }
         }
-    }
 }
 ```

--- a/site-docs/features.md
+++ b/site-docs/features.md
@@ -1,0 +1,122 @@
+# Features Guide
+
+A **Feature** transforms a stream of intentions into a stream of outcomes. Each feature is responsible for one piece of logic.
+
+## FunctionTypedFeature — simplest
+
+For one-shot operations (no streaming, no background work):
+
+```kotlin
+val incrementFeature = functionTypedFeature<CounterState, CounterIntention.Increment> { _ ->
+    StateOutcome { state -> state.copy(count = state.count + 1) }
+}
+```
+
+Or as a class:
+
+```kotlin
+class IncrementFeature : FunctionTypedFeature<CounterState, CounterIntention.Increment> {
+    override suspend fun invoke(intention: CounterIntention.Increment): Outcome<CounterState> =
+        StateOutcome { state -> state.copy(count = state.count + 1) }
+}
+```
+
+Use `.wrap()` to convert to `Feature<S>`:
+```kotlin
+IncrementFeature().wrap()
+```
+
+> **Note:** Multiple concurrent intentions are processed concurrently. If your `invoke` does async work (network, DB), each intention gets its own coroutine automatically.
+
+## TypedFeature — typed streaming
+
+For features that transform a stream of intentions:
+
+```kotlin
+class FetchDataFeature(
+    private val repository: DataRepository,
+) : TypedFeature<AppState, AppIntention.Fetch> {
+    override fun invoke(
+        intentions: Flow<AppIntention.Fetch>
+    ): Flow<Outcome<AppState>> = channelFlow {
+        intentions.collect { intention ->
+            try {
+                val data = repository.fetch(intention.id)  // suspend call
+                send(StateOutcome { state -> state.copy(data = data) })
+            } catch (e: Exception) {
+                send(StateOutcome { state -> state.copy(error = e.message) })
+            }
+        }
+    }
+}
+```
+
+Use `.wrap()` to convert:
+```kotlin
+FetchDataFeature(repository).wrap()
+```
+
+## TypedFeature with background work
+
+Use `channelFlow { }` when you need to launch background coroutines (timers, polling):
+
+```kotlin
+class AutoIncrementFeature : TypedFeature<CounterState, CounterIntention.StartAuto> {
+    override fun invoke(
+        intentions: Flow<CounterIntention.StartAuto>
+    ): Flow<Outcome<CounterState>> = channelFlow {
+        var timerJob: Job? = null
+        intentions.collect { _ ->
+            timerJob?.cancel()
+            timerJob = launch {
+                while (isActive) {
+                    delay(1_000)
+                    send(StateOutcome { state -> state.copy(count = state.count + 1) })
+                }
+            }
+        }
+    }
+}
+```
+
+The `channelFlow` block's `this` is a `ProducerScope` (a `CoroutineScope` + `send()`). Any `launch { }` inside is a child of the feature's coroutine — cancelled automatically when the ViewModel is cleared.
+
+## FlowFeature — low-level
+
+For features that need to handle multiple intention types or work with the raw `Flow<Any>`:
+
+```kotlin
+class LoggingFeature : Feature.FlowUnitFeature<AppState> {
+    override fun invoke(intentions: Flow<Any>): Flow<Unit> =
+        intentions.onEach { intention ->
+            Log.d("YAMV", "Intention dispatched: $intention")
+        }
+}
+```
+
+## Combining Outcomes
+
+A single feature can emit multiple outcome types:
+
+```kotlin
+class LoginFeature(
+    private val auth: AuthService,
+) : TypedFeature<AppState, AppIntention.Login> {
+    override fun invoke(
+        intentions: Flow<AppIntention.Login>
+    ): Flow<Outcome<AppState>> = channelFlow {
+        intentions.collect { intention ->
+            try {
+                val user = auth.login(intention.email, intention.password)
+                send(StateOutcome { state -> state.copy(user = user, isLoading = false) })
+                send(object : IntentionOutcome<AppState> {
+                    override val intention = AppIntention.LoadDashboard
+                })
+            } catch (e: AuthException) {
+                send(StateOutcome { state -> state.copy(error = e.message, isLoading = false) })
+                send(object : EffectOutcome<AppState> {})  // trigger snackbar, etc.
+            }
+        }
+    }
+}
+```

--- a/site-docs/getting-started.md
+++ b/site-docs/getting-started.md
@@ -83,24 +83,24 @@ sealed class CounterIntention {
 }
 ```
 
-### 3. Define Reducers
+### 3. Define Outcomes
 
-Declare reducers as standalone classes. They are pure `(S) -> S` functions, decoupled from features and testable without coroutines:
+Declare outcomes as standalone classes. They are pure `(S) -> S` functions, decoupled from features and testable without coroutines:
 
 ```kotlin
 import com.ktomek.yamv.core.StateOutcome
 
-class IncrementReducer : StateOutcome<CounterState> {
+class IncrementOutcome : StateOutcome<CounterState> {
     override fun reduce(prevState: CounterState) =
         prevState.copy(count = prevState.count + 1)
 }
 
-class DecrementReducer : StateOutcome<CounterState> {
+class DecrementOutcome : StateOutcome<CounterState> {
     override fun reduce(prevState: CounterState) =
         prevState.copy(count = prevState.count - 1)
 }
 
-class SetValueReducer(private val value: Int) : StateOutcome<CounterState> {
+class SetValueOutcome(private val value: Int) : StateOutcome<CounterState> {
     override fun reduce(prevState: CounterState) =
         prevState.copy(count = value)
 }
@@ -108,7 +108,7 @@ class SetValueReducer(private val value: Int) : StateOutcome<CounterState> {
 
 ### 4. Write Features
 
-Each feature maps intentions to outcomes (reducers):
+Each feature maps intentions to outcomes:
 
 ```kotlin
 import com.ktomek.yamv.annotations.AutoFeature
@@ -121,7 +121,7 @@ class IncrementFeature : TypedFeature<CounterState, CounterIntention.Increment> 
     override fun invoke(
         intentions: Flow<CounterIntention.Increment>
     ): Flow<Outcome<CounterState>> =
-        intentions.map { IncrementReducer() }
+        intentions.map { IncrementOutcome() }
 }
 
 @AutoFeature
@@ -129,7 +129,7 @@ class DecrementFeature : TypedFeature<CounterState, CounterIntention.Decrement> 
     override fun invoke(
         intentions: Flow<CounterIntention.Decrement>
     ): Flow<Outcome<CounterState>> =
-        intentions.map { DecrementReducer() }
+        intentions.map { DecrementOutcome() }
 }
 ```
 

--- a/site-docs/getting-started.md
+++ b/site-docs/getting-started.md
@@ -41,7 +41,7 @@ plugins {
     dependencies {
         implementation("com.github.ktomek.yamv:core:VERSION")
         implementation("com.github.ktomek.yamv:yamv:VERSION")
-        implementation("com.github.ktomek.yamv:yamv-viewmodel:VERSION")
+        implementation("com.github.ktomek.yamv:yamv-retainer:VERSION")
         implementation("com.github.ktomek.yamv:yamv-hilt:VERSION")
         ksp("com.github.ktomek.yamv:processor-hilt:VERSION")
     }
@@ -54,7 +54,7 @@ plugins {
     dependencies {
         implementation("com.github.ktomek.yamv:core:VERSION")
         implementation("com.github.ktomek.yamv:yamv:VERSION")
-        implementation("com.github.ktomek.yamv:yamv-viewmodel:VERSION")
+        implementation("com.github.ktomek.yamv:yamv-retainer:VERSION")
         implementation("com.github.ktomek.yamv:yamv-koin:VERSION")
     }
     ```
@@ -71,7 +71,7 @@ import com.ktomek.yamv.annotations.AutoState
 data class CounterState(val count: Int = 0) : State
 ```
 
-`@AutoState` triggers KSP to generate `CounterStateStore` — a `@HiltViewModel` subclass of `MviViewModel<CounterState, Any>`.
+`@AutoState` triggers KSP to generate `CounterStateStore` — a `@HiltViewModel` subclass of `MviRetainedStore<CounterState, Any>`.
 
 ### 2. Define Intentions
 
@@ -83,14 +83,36 @@ sealed class CounterIntention {
 }
 ```
 
-### 3. Write Features
+### 3. Define Reducers
 
-Each feature handles one type of intention:
+Declare reducers as standalone classes. They are pure `(S) -> S` functions, decoupled from features and testable without coroutines:
+
+```kotlin
+import com.ktomek.yamv.core.StateOutcome
+
+class IncrementReducer : StateOutcome<CounterState> {
+    override fun reduce(prevState: CounterState) =
+        prevState.copy(count = prevState.count + 1)
+}
+
+class DecrementReducer : StateOutcome<CounterState> {
+    override fun reduce(prevState: CounterState) =
+        prevState.copy(count = prevState.count - 1)
+}
+
+class SetValueReducer(private val value: Int) : StateOutcome<CounterState> {
+    override fun reduce(prevState: CounterState) =
+        prevState.copy(count = value)
+}
+```
+
+### 4. Write Features
+
+Each feature maps intentions to outcomes (reducers):
 
 ```kotlin
 import com.ktomek.yamv.annotations.AutoFeature
 import com.ktomek.yamv.feature.TypedFeature
-import com.ktomek.yamv.core.StateOutcome
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 
@@ -99,7 +121,7 @@ class IncrementFeature : TypedFeature<CounterState, CounterIntention.Increment> 
     override fun invoke(
         intentions: Flow<CounterIntention.Increment>
     ): Flow<Outcome<CounterState>> =
-        intentions.map { StateOutcome { state -> state.copy(count = state.count + 1) } }
+        intentions.map { IncrementReducer() }
 }
 
 @AutoFeature
@@ -107,11 +129,11 @@ class DecrementFeature : TypedFeature<CounterState, CounterIntention.Decrement> 
     override fun invoke(
         intentions: Flow<CounterIntention.Decrement>
     ): Flow<Outcome<CounterState>> =
-        intentions.map { StateOutcome { state -> state.copy(count = state.count - 1) } }
+        intentions.map { DecrementReducer() }
 }
 ```
 
-### 4. Collect State in Compose
+### 5. Collect State in Compose
 
 === "Hilt"
 

--- a/site-docs/getting-started.md
+++ b/site-docs/getting-started.md
@@ -1,0 +1,146 @@
+# Getting Started
+
+## Prerequisites
+
+- Android Studio Hedgehog or newer
+- Kotlin 2.0+
+- KSP plugin (for `@AutoState`/`@AutoFeature` code generation)
+
+## Installation
+
+### Step 1: Add JitPack repository
+
+In your project's `settings.gradle.kts`:
+
+```kotlin
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+        maven { url = uri("https://jitpack.io") }
+    }
+}
+```
+
+### Step 2: Add KSP plugin
+
+In your app module's `build.gradle.kts`:
+
+```kotlin
+plugins {
+    id("com.google.devtools.ksp") version "2.0.21-1.0.28"
+}
+```
+
+### Step 3: Add dependencies
+
+=== "Hilt (Android)"
+
+    ```kotlin
+    dependencies {
+        implementation("com.github.ktomek.yamv:core:VERSION")
+        implementation("com.github.ktomek.yamv:yamv:VERSION")
+        implementation("com.github.ktomek.yamv:yamv-viewmodel:VERSION")
+        implementation("com.github.ktomek.yamv:yamv-hilt:VERSION")
+        ksp("com.github.ktomek.yamv:processor-hilt:VERSION")
+    }
+    ```
+
+=== "Koin (Multiplatform)"
+
+    ```kotlin
+    // commonMain
+    dependencies {
+        implementation("com.github.ktomek.yamv:core:VERSION")
+        implementation("com.github.ktomek.yamv:yamv:VERSION")
+        implementation("com.github.ktomek.yamv:yamv-viewmodel:VERSION")
+        implementation("com.github.ktomek.yamv:yamv-koin:VERSION")
+    }
+    ```
+
+## Your First Feature
+
+### 1. Define State
+
+```kotlin
+import com.ktomek.yamv.core.State
+import com.ktomek.yamv.annotations.AutoState
+
+@AutoState
+data class CounterState(val count: Int = 0) : State
+```
+
+`@AutoState` triggers KSP to generate `CounterStateStore` — a `@HiltViewModel` subclass of `MviViewModel<CounterState, Any>`.
+
+### 2. Define Intentions
+
+```kotlin
+sealed class CounterIntention {
+    data object Increment : CounterIntention()
+    data object Decrement : CounterIntention()
+    data class SetValue(val value: Int) : CounterIntention()
+}
+```
+
+### 3. Write Features
+
+Each feature handles one type of intention:
+
+```kotlin
+import com.ktomek.yamv.annotations.AutoFeature
+import com.ktomek.yamv.feature.TypedFeature
+import com.ktomek.yamv.core.StateOutcome
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
+@AutoFeature
+class IncrementFeature : TypedFeature<CounterState, CounterIntention.Increment> {
+    override fun invoke(
+        intentions: Flow<CounterIntention.Increment>
+    ): Flow<Outcome<CounterState>> =
+        intentions.map { StateOutcome { state -> state.copy(count = state.count + 1) } }
+}
+
+@AutoFeature
+class DecrementFeature : TypedFeature<CounterState, CounterIntention.Decrement> {
+    override fun invoke(
+        intentions: Flow<CounterIntention.Decrement>
+    ): Flow<Outcome<CounterState>> =
+        intentions.map { StateOutcome { state -> state.copy(count = state.count - 1) } }
+}
+```
+
+### 4. Collect State in Compose
+
+=== "Hilt"
+
+    ```kotlin
+    @Composable
+    fun CounterScreen(vm: CounterStateStore = hiltMviStore()) {
+        val state by vm.state.collectAsStateWithLifecycle()
+        CounterContent(
+            count = state.count,
+            onIncrement = { vm.dispatch(CounterIntention.Increment) },
+            onDecrement = { vm.dispatch(CounterIntention.Decrement) },
+        )
+    }
+    ```
+
+=== "Koin"
+
+    ```kotlin
+    @Composable
+    fun CounterScreen(vm: CounterStateStore = koinMviStore()) {
+        val state by vm.state.collectAsStateWithLifecycle()
+        // same as above
+    }
+    ```
+
+## Running the Sample App
+
+The `:app:hilt` module is a working counter demo:
+
+```bash
+./gradlew :app:hilt:installDebug
+```

--- a/site-docs/getting-started.md
+++ b/site-docs/getting-started.md
@@ -139,12 +139,12 @@ class DecrementFeature : TypedFeature<CounterState, CounterIntention.Decrement> 
 
     ```kotlin
     @Composable
-    fun CounterScreen(vm: CounterStateStore = hiltMviStore()) {
-        val state by vm.state.collectAsStateWithLifecycle()
+    fun CounterScreen(store: CounterStateStore = hiltMviStore()) {
+        val state by store.state.collectAsStateWithLifecycle()
         CounterContent(
             count = state.count,
-            onIncrement = { vm.dispatch(CounterIntention.Increment) },
-            onDecrement = { vm.dispatch(CounterIntention.Decrement) },
+            onIncrement = { store.dispatch(CounterIntention.Increment) },
+            onDecrement = { store.dispatch(CounterIntention.Decrement) },
         )
     }
     ```
@@ -153,8 +153,8 @@ class DecrementFeature : TypedFeature<CounterState, CounterIntention.Decrement> 
 
     ```kotlin
     @Composable
-    fun CounterScreen(vm: CounterStateStore = koinMviStore()) {
-        val state by vm.state.collectAsStateWithLifecycle()
+    fun CounterScreen(store: CounterStateStore = koinMviStore()) {
+        val state by store.state.collectAsStateWithLifecycle()
         // same as above
     }
     ```

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -14,14 +14,20 @@ MVI architecture brings predictability to UI state. YAMV makes it production-rea
 
 ## Core Concepts
 
-```
-UI dispatches Intention
-    → FeatureRouter routes to matching Features
-        → Features emit Outcomes
-            → StateOutcome  → reduces state (pure function)
-            → EffectOutcome → side effect (navigation, toast, etc.)
-            → IntentionOutcome → dispatches another intention
-    → StateFlow<S> updates UI
+``` mermaid
+flowchart LR
+    UI["🖥️ UI\ndispatch()"] -->|Intention| Router["🚦 FeatureRouter"]
+    Router --> Features["🧩 Features"]
+    Features -->|StateOutcome| State["🔄 reduces state"]
+    Features -->|EffectOutcome| Effect["⚡ side effect"]
+    Features -->|IntentionOutcome| Router
+    State -->|"StateFlow‹S›"| UI
+
+    style UI fill:#7c4dff,color:#fff,stroke:#7c4dff
+    style Router fill:#aa00ff,color:#fff,stroke:#aa00ff
+    style Features fill:#d500f9,color:#fff,stroke:#d500f9
+    style State fill:#651fff,color:#fff,stroke:#651fff
+    style Effect fill:#6200ea,color:#fff,stroke:#6200ea
 ```
 
 ## Modules at a Glance

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -6,11 +6,11 @@ A Kotlin-first **MVI (Model-View-Intent)** framework for Android & Kotlin Multip
 
 MVI architecture brings predictability to UI state. YAMV makes it production-ready:
 
-- **Compile-time safety** — KSP generates your ViewModels and DI modules
+- **Compile-time safety** — KSP generates your retained stores and DI modules
 - **Zero runtime reflection** — all wiring happens at build time
 - **Coroutine-native** — built on Kotlin Coroutines and Flow, no RxJava
 - **Multiplatform** — same framework for Android (Hilt/Koin) and iOS (Koin + Compose Multiplatform)
-- **Testable** — pure Kotlin core with no Android dependencies; test with JUnit 5 + Turbine
+- **Testable** — pure Kotlin core with no Android dependencies; reducers are standalone classes testable without coroutines
 
 ## Core Concepts
 
@@ -30,10 +30,10 @@ UI dispatches Intention
 |--------|-----------------|
 | `core` | `State`, `Outcome`, `@AutoState`, `@AutoFeature` |
 | `yamv` | `MviRuntime`, `MviStore`, `FeatureRouter`, feature builders |
-| `yamv-viewmodel` | `MviViewModel` (Android + iOS) |
+| `yamv-retainer` | `MviRetainedStore` (Android ViewModel + iOS) |
 | `yamv-hilt` | `hiltMviStore()` Compose helper |
-| `yamv-koin` | `koinMviStore()` Compose helper |
-| `processor-hilt` | KSP: generates `*Store` ViewModel + `*FeaturesModule` |
+| `yamv-koin` | `koinMviStore()` / `mviStore {}` DSL |
+| `processor-hilt` | KSP: generates `*Store` retained store + `*FeaturesModule` |
 
 ## Quick Install
 

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -1,0 +1,40 @@
+# YAMV — Yet Another MVI Framework
+
+A Kotlin-first **MVI (Model-View-Intent)** framework for Android & Kotlin Multiplatform with compile-time code generation via KSP.
+
+## Why YAMV?
+
+MVI architecture brings predictability to UI state. YAMV makes it production-ready:
+
+- **Compile-time safety** — KSP generates your ViewModels and DI modules
+- **Zero runtime reflection** — all wiring happens at build time
+- **Coroutine-native** — built on Kotlin Coroutines and Flow, no RxJava
+- **Multiplatform** — same framework for Android (Hilt/Koin) and iOS (Koin + Compose Multiplatform)
+- **Testable** — pure Kotlin core with no Android dependencies; test with JUnit 5 + Turbine
+
+## Core Concepts
+
+```
+UI dispatches Intention
+    → FeatureRouter routes to matching Features
+        → Features emit Outcomes
+            → StateOutcome  → reduces state (pure function)
+            → EffectOutcome → side effect (navigation, toast, etc.)
+            → IntentionOutcome → dispatches another intention
+    → StateFlow<S> updates UI
+```
+
+## Modules at a Glance
+
+| Module | What it provides |
+|--------|-----------------|
+| `core` | `State`, `Outcome`, `@AutoState`, `@AutoFeature` |
+| `yamv` | `MviRuntime`, `MviStore`, `FeatureRouter`, feature builders |
+| `yamv-viewmodel` | `MviViewModel` (Android + iOS) |
+| `yamv-hilt` | `hiltMviStore()` Compose helper |
+| `yamv-koin` | `koinMviStore()` Compose helper |
+| `processor-hilt` | KSP: generates `*Store` ViewModel + `*FeaturesModule` |
+
+## Quick Install
+
+See [Getting Started](getting-started.md) for full setup instructions.

--- a/site-docs/multiplatform.md
+++ b/site-docs/multiplatform.md
@@ -64,8 +64,8 @@ val counterModule = module {
 ```kotlin
 // commonMain
 @Composable
-fun CounterScreen(vm: KoinMviRetainedStore<CounterState> = koinMviStore()) {
-    val state by vm.state.collectAsStateWithLifecycle()
+fun CounterScreen(store: KoinMviRetainedStore<CounterState> = koinMviStore()) {
+    val state by store.state.collectAsStateWithLifecycle()
     // ...
 }
 ```

--- a/site-docs/multiplatform.md
+++ b/site-docs/multiplatform.md
@@ -1,0 +1,69 @@
+# Multiplatform Setup
+
+YAMV supports Kotlin Multiplatform for sharing state logic between Android and iOS via Compose Multiplatform.
+
+## Supported Targets
+
+| Target | Status |
+|--------|--------|
+| Android (Hilt) | Stable |
+| Android (Koin) | Stable |
+| iOS (Koin + Compose Multiplatform) | Stable |
+
+## iOS + Koin Setup
+
+### 1. Add Koin dependencies to commonMain
+
+```kotlin
+// shared/build.gradle.kts
+kotlin {
+    sourceSets {
+        commonMain.dependencies {
+            implementation("com.github.ktomek.yamv:yamv:VERSION")
+            implementation("com.github.ktomek.yamv:yamv-viewmodel:VERSION")
+            implementation("com.github.ktomek.yamv:yamv-koin:VERSION")
+        }
+    }
+}
+```
+
+### 2. Create your Koin module
+
+```kotlin
+// commonMain
+val counterModule = module {
+    factory { CounterState() }
+    factoryOf(::IncrementFeature)
+    factoryOf(::DecrementFeature)
+    factory<MviStore<CounterState, Any>> {
+        MviRuntime(
+            features = setOf(get<IncrementFeature>().wrap(), get<DecrementFeature>().wrap()),
+            defaultState = CounterState(),
+        )
+    }
+}
+```
+
+### 3. Use in Compose
+
+```kotlin
+// commonMain
+@Composable
+fun CounterScreen(vm: CounterStateStore = koinMviStore()) {
+    val state by vm.state.collectAsStateWithLifecycle()
+    // ...
+}
+```
+
+### 4. iOS entry point
+
+```kotlin
+// iosMain
+fun MainViewController() = ComposeUIViewController {
+    App()
+}
+```
+
+## StateHandle on iOS
+
+`MviViewModel` uses `StateHandle` for saved state restoration. On iOS, `IosStateHandle` provides a no-op implementation (iOS ViewModel lifecycle manages this differently).

--- a/site-docs/multiplatform.md
+++ b/site-docs/multiplatform.md
@@ -29,7 +29,7 @@ kotlin {
 
 ### 2. Create your Koin module
 
-Using the `mviStore {}` DSL — features are wrapped automatically:
+Using the `mviStore {}` DSL — typed features are wrapped automatically via `add()`:
 
 ```kotlin
 // commonMain
@@ -37,8 +37,8 @@ val counterModule = module {
     factoryOf(::IncrementFeature)
     factoryOf(::DecrementFeature)
     mviStore(defaultState = CounterState()) {
-        feature { get<IncrementFeature>() }
-        feature { get<DecrementFeature>() }
+        add(get<IncrementFeature>())   // .wrap() applied automatically
+        add(get<DecrementFeature>())
     }
 }
 ```

--- a/site-docs/multiplatform.md
+++ b/site-docs/multiplatform.md
@@ -20,7 +20,7 @@ kotlin {
     sourceSets {
         commonMain.dependencies {
             implementation("com.github.ktomek.yamv:yamv:VERSION")
-            implementation("com.github.ktomek.yamv:yamv-viewmodel:VERSION")
+            implementation("com.github.ktomek.yamv:yamv-retainer:VERSION")
             implementation("com.github.ktomek.yamv:yamv-koin:VERSION")
         }
     }
@@ -29,15 +29,30 @@ kotlin {
 
 ### 2. Create your Koin module
 
+Using the `mviStore {}` DSL — features are wrapped automatically:
+
 ```kotlin
 // commonMain
 val counterModule = module {
-    factory { CounterState() }
     factoryOf(::IncrementFeature)
     factoryOf(::DecrementFeature)
+    mviStore(defaultState = CounterState()) {
+        feature { get<IncrementFeature>() }
+        feature { get<DecrementFeature>() }
+    }
+}
+```
+
+Or manual wiring with explicit `.wrap()`:
+
+```kotlin
+val counterModule = module {
     factory<MviStore<CounterState, Any>> {
         MviRuntime(
-            features = setOf(get<IncrementFeature>().wrap(), get<DecrementFeature>().wrap()),
+            features = setOf(
+                IncrementFeature().wrap(),
+                DecrementFeature().wrap(),
+            ),
             defaultState = CounterState(),
         )
     }
@@ -49,7 +64,7 @@ val counterModule = module {
 ```kotlin
 // commonMain
 @Composable
-fun CounterScreen(vm: CounterStateStore = koinMviStore()) {
+fun CounterScreen(vm: KoinMviRetainedStore<CounterState> = koinMviStore()) {
     val state by vm.state.collectAsStateWithLifecycle()
     // ...
 }
@@ -63,7 +78,3 @@ fun MainViewController() = ComposeUIViewController {
     App()
 }
 ```
-
-## StateHandle on iOS
-
-`MviViewModel` uses `StateHandle` for saved state restoration. On iOS, `IosStateHandle` provides a no-op implementation (iOS ViewModel lifecycle manages this differently).

--- a/yamv/src/test/kotlin/com/ktomek/yamv/feature/HasFeatureDispatcherTest.kt
+++ b/yamv/src/test/kotlin/com/ktomek/yamv/feature/HasFeatureDispatcherTest.kt
@@ -21,5 +21,4 @@ class HasFeatureDispatcherTest {
 
         assertThat(scope.featureDispatcher).isEqualTo(Dispatchers.Default)
     }
-
 }


### PR DESCRIPTION
## Summary
- Adds `README.md` with badges, quick-start guide, module table, and links to full docs
- Adds `mkdocs.yml` + `site-docs/` with 7 pages: home, getting started, architecture, features guide, code generation, multiplatform, changelog
- Adds `.github/workflows/docs.yml` — auto-deploys MkDocs site to GitHub Pages on push to `main`

## Test Plan
- [ ] README renders correctly on GitHub (badges, code blocks, table)
- [ ] `python3 -c "import yaml; yaml.safe_load(open('mkdocs.yml'))"` passes
- [ ] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/docs.yml'))"` passes
- [ ] All existing tests still pass (`./gradlew :yamv:jvmTest`)