### PR TITLE
[#12] feat: expose CoroutineDispatcherConfig in MviRetainedStore and Koin DSL

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,6 +9,7 @@ plugins {
     alias(libs.plugins.detekt) apply true
     alias(libs.plugins.compose.compiler) apply false
     alias(libs.plugins.compose.multiplatform) apply false
+    alias(libs.plugins.allopen) apply false
     `maven-publish`
 }
 

--- a/core/src/main/kotlin/com/ktomek/yamv/annotations/OpenForTesting.kt
+++ b/core/src/main/kotlin/com/ktomek/yamv/annotations/OpenForTesting.kt
@@ -1,0 +1,11 @@
+package com.ktomek.yamv.annotations
+
+/**
+ * Marks a class as intentionally open for test subclassing.
+ *
+ * The [allopen] compiler plugin is configured to honor this annotation only in test compilations,
+ * so the class remains final in production bytecode.
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.BINARY)
+annotation class OpenForTesting

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,6 +42,7 @@ detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 compose-multiplatform = { id = "org.jetbrains.compose", version.ref = "compose-multiplatform" }
+allopen = { id = "org.jetbrains.kotlin.plugin.allopen", version.ref = "kotlin" }
 
 [libraries]
 # Kotlin standard library

--- a/processor-hilt/src/main/kotlin/com/ktomek/yamv/processor/hilt/HiltClassNames.kt
+++ b/processor-hilt/src/main/kotlin/com/ktomek/yamv/processor/hilt/HiltClassNames.kt
@@ -22,7 +22,6 @@ internal object YamvClassNames {
     val Feature = ClassName("com.ktomek.yamv.feature", "Feature")
     const val WrapImportPackage = "com.ktomek.yamv.feature"
     const val WrapImportName = "wrap"
-    val CoroutineDispatcherConfig = ClassName("com.ktomek.yamv.state", "CoroutineDispatcherConfig")
 }
 
 internal object FeatureFqns {

--- a/processor-hilt/src/main/kotlin/com/ktomek/yamv/processor/hilt/HiltClassNames.kt
+++ b/processor-hilt/src/main/kotlin/com/ktomek/yamv/processor/hilt/HiltClassNames.kt
@@ -22,6 +22,7 @@ internal object YamvClassNames {
     val Feature = ClassName("com.ktomek.yamv.feature", "Feature")
     const val WrapImportPackage = "com.ktomek.yamv.feature"
     const val WrapImportName = "wrap"
+    val CoroutineDispatcherConfig = ClassName("com.ktomek.yamv.state", "CoroutineDispatcherConfig")
 }
 
 internal object FeatureFqns {

--- a/processor-hilt/src/main/kotlin/com/ktomek/yamv/processor/hilt/ViewModelGenerator.kt
+++ b/processor-hilt/src/main/kotlin/com/ktomek/yamv/processor/hilt/ViewModelGenerator.kt
@@ -90,7 +90,7 @@ internal class ViewModelGenerator(private val codeGenerator: CodeGenerator) {
         )
             .addModifiers(KModifier.OVERRIDE)
             .initializer(
-                "%T(\n  features = features,\n  defaultState = %T(),\n)",
+                "%T(\n  features = features,\n  defaultState = %T(),\n  dispatcherConfig = dispatcherConfig,\n)",
                 YamvClassNames.MviRuntime,
                 defaultStateClass,
             )

--- a/processor-hilt/src/main/kotlin/com/ktomek/yamv/processor/hilt/ViewModelGenerator.kt
+++ b/processor-hilt/src/main/kotlin/com/ktomek/yamv/processor/hilt/ViewModelGenerator.kt
@@ -29,6 +29,7 @@ import com.squareup.kotlinpoet.ksp.writeTo
  *     override val store: MviStore<CounterState, Any> = MviRuntime(
  *         features = features,
  *         defaultState = CounterState(),
+ *         dispatcherConfig = dispatcherConfig,
  *     )
  * }
  * ```

--- a/yamv-koin/build.gradle.kts
+++ b/yamv-koin/build.gradle.kts
@@ -5,6 +5,7 @@ plugins {
     id("com.android.library")
     id("org.jetbrains.compose")
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.allopen)
     `maven-publish`
 }
 
@@ -48,6 +49,10 @@ kotlin {
             implementation(libs.bundles.testing.unit)
         }
     }
+}
+
+allOpen {
+    annotation("com.ktomek.yamv.annotations.OpenForTesting")
 }
 
 publishing {

--- a/yamv-koin/build.gradle.kts
+++ b/yamv-koin/build.gradle.kts
@@ -18,6 +18,9 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
+    testOptions {
+        unitTests.all { it.useJUnitPlatform() }
+    }
 }
 
 kotlin {
@@ -40,6 +43,9 @@ kotlin {
         }
         androidMain.dependencies {
             implementation(libs.koin.android)
+        }
+        androidUnitTest.dependencies {
+            implementation(libs.bundles.testing.unit)
         }
     }
 }

--- a/yamv-koin/src/commonMain/kotlin/com/ktomek/yamv/koin/KoinMviRetainedStore.kt
+++ b/yamv-koin/src/commonMain/kotlin/com/ktomek/yamv/koin/KoinMviRetainedStore.kt
@@ -1,6 +1,7 @@
 package com.ktomek.yamv.koin
 
 import androidx.compose.runtime.Composable
+import com.ktomek.yamv.annotations.OpenForTesting
 import com.ktomek.yamv.core.State
 import com.ktomek.yamv.feature.Feature
 import com.ktomek.yamv.retainer.MviRetainedStore
@@ -20,7 +21,8 @@ import org.koin.core.qualifier.named
  * Replaces per-state generated classes (e.g. `CounterStateStore`). Register it via [mviStore]
  * and retrieve it via [koinMviStore] — both derive the Koin qualifier from [S] automatically.
  */
-open class KoinMviRetainedStore<S : State>(
+@OpenForTesting
+class KoinMviRetainedStore<S : State>(
     features: Set<Feature<S>>,
     defaultState: S,
     dispatcherConfig: CoroutineDispatcherConfig = DefaultCoroutineDispatcherConfig(),

--- a/yamv-koin/src/commonMain/kotlin/com/ktomek/yamv/koin/KoinMviRetainedStore.kt
+++ b/yamv-koin/src/commonMain/kotlin/com/ktomek/yamv/koin/KoinMviRetainedStore.kt
@@ -25,7 +25,7 @@ open class KoinMviRetainedStore<S : State>(
     defaultState: S,
     dispatcherConfig: CoroutineDispatcherConfig = DefaultCoroutineDispatcherConfig(),
 ) : MviRetainedStore<S, Any>() {
-    public override val dispatcherConfig: CoroutineDispatcherConfig = dispatcherConfig
+    override val dispatcherConfig: CoroutineDispatcherConfig = dispatcherConfig
     override val store: MviStore<S, Any> = MviRuntime(
         features = features,
         defaultState = defaultState,

--- a/yamv-koin/src/commonMain/kotlin/com/ktomek/yamv/koin/KoinMviRetainedStore.kt
+++ b/yamv-koin/src/commonMain/kotlin/com/ktomek/yamv/koin/KoinMviRetainedStore.kt
@@ -20,12 +20,12 @@ import org.koin.core.qualifier.named
  * Replaces per-state generated classes (e.g. `CounterStateStore`). Register it via [mviStore]
  * and retrieve it via [koinMviStore] — both derive the Koin qualifier from [S] automatically.
  */
-class KoinMviRetainedStore<S : State>(
+open class KoinMviRetainedStore<S : State>(
     features: Set<Feature<S>>,
     defaultState: S,
     dispatcherConfig: CoroutineDispatcherConfig = DefaultCoroutineDispatcherConfig(),
 ) : MviRetainedStore<S, Any>() {
-    override val dispatcherConfig: CoroutineDispatcherConfig = dispatcherConfig
+    public override val dispatcherConfig: CoroutineDispatcherConfig = dispatcherConfig
     override val store: MviStore<S, Any> = MviRuntime(
         features = features,
         defaultState = defaultState,

--- a/yamv-koin/src/commonMain/kotlin/com/ktomek/yamv/koin/KoinMviRetainedStore.kt
+++ b/yamv-koin/src/commonMain/kotlin/com/ktomek/yamv/koin/KoinMviRetainedStore.kt
@@ -4,6 +4,8 @@ import androidx.compose.runtime.Composable
 import com.ktomek.yamv.core.State
 import com.ktomek.yamv.feature.Feature
 import com.ktomek.yamv.retainer.MviRetainedStore
+import com.ktomek.yamv.state.CoroutineDispatcherConfig
+import com.ktomek.yamv.state.DefaultCoroutineDispatcherConfig
 import com.ktomek.yamv.state.MviRuntime
 import com.ktomek.yamv.state.MviStore
 import org.koin.compose.viewmodel.koinViewModel
@@ -21,10 +23,13 @@ import org.koin.core.qualifier.named
 class KoinMviRetainedStore<S : State>(
     features: Set<Feature<S>>,
     defaultState: S,
+    dispatcherConfig: CoroutineDispatcherConfig = DefaultCoroutineDispatcherConfig(),
 ) : MviRetainedStore<S, Any>() {
+    override val dispatcherConfig: CoroutineDispatcherConfig = dispatcherConfig
     override val store: MviStore<S, Any> = MviRuntime(
         features = features,
         defaultState = defaultState,
+        dispatcherConfig = dispatcherConfig,
     )
 }
 
@@ -57,12 +62,17 @@ inline fun <reified S : State> stateQualifier(): Qualifier = named(S::class.simp
  */
 inline fun <reified S : State> Module.mviStore(
     defaultState: S,
+    dispatcherConfig: CoroutineDispatcherConfig = DefaultCoroutineDispatcherConfig(),
     crossinline features: FeatureRegistrar<S>.() -> Unit,
 ) {
     viewModel(stateQualifier<S>()) {
         val registrar = FeatureRegistrar<S>(this)
         registrar.features()
-        KoinMviRetainedStore(features = registrar.build(), defaultState = defaultState)
+        KoinMviRetainedStore(
+            features = registrar.build(),
+            defaultState = defaultState,
+            dispatcherConfig = dispatcherConfig,
+        )
     }
 }
 

--- a/yamv-koin/src/test/kotlin/com/ktomek/yamv/koin/KoinMviRetainedStoreDispatcherConfigTest.kt
+++ b/yamv-koin/src/test/kotlin/com/ktomek/yamv/koin/KoinMviRetainedStoreDispatcherConfigTest.kt
@@ -8,7 +8,11 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
+import org.koin.core.KoinApplication
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
 import kotlin.test.assertEquals
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
@@ -39,7 +43,9 @@ private class TrackingCoroutineDispatcherConfig(
 }
 
 /**
- * Subclass of [KoinMviRetainedStore] that exposes [dispatcherConfig] for assertion in tests.
+ * Subclass of [KoinMviRetainedStore] used in tests that require construction via a named config parameter.
+ *
+ * Since [KoinMviRetainedStore.dispatcherConfig] is public, no extra accessor is needed.
  */
 private class InspectableMviRetainedStore<S : State>(
     features: Set<Feature<S>>,
@@ -49,11 +55,14 @@ private class InspectableMviRetainedStore<S : State>(
     features = features,
     defaultState = defaultState,
     dispatcherConfig = config,
-) {
-    fun getDispatcherConfig(): CoroutineDispatcherConfig = dispatcherConfig
-}
+)
 
 class KoinMviRetainedStoreDispatcherConfigTest {
+
+    @AfterEach
+    fun tearDown() {
+        stopKoin()
+    }
 
     @Test
     fun `GIVEN KoinMviRetainedStore with default config WHEN created THEN dispatcherConfig is DefaultCoroutineDispatcherConfig`() {
@@ -65,7 +74,7 @@ class KoinMviRetainedStoreDispatcherConfigTest {
         )
 
         // Assert
-        assertTrue(store.getDispatcherConfig() is DefaultCoroutineDispatcherConfig)
+        assertTrue(store.dispatcherConfig is DefaultCoroutineDispatcherConfig)
     }
 
     @Test
@@ -81,7 +90,7 @@ class KoinMviRetainedStoreDispatcherConfigTest {
         )
 
         // Assert
-        assertSame(customConfig, store.getDispatcherConfig())
+        assertSame(customConfig, store.dispatcherConfig)
     }
 
     @Test
@@ -126,5 +135,21 @@ class KoinMviRetainedStoreDispatcherConfigTest {
             customConfig.intentionDispatcherCallCount,
             "Expected intentionDispatcherCallCount to increase by 1",
         )
+    }
+
+    @Test
+    fun `GIVEN mviStore DSL with custom dispatcherConfig WHEN resolved via Koin THEN store has custom dispatcherConfig`() {
+        // Arrange
+        val customConfig = TrackingCoroutineDispatcherConfig()
+        val koinModule = module {
+            mviStore(defaultState = TestState(), dispatcherConfig = customConfig) {}
+        }
+
+        // Act
+        val koinApp = KoinApplication.init().modules(koinModule)
+        val store = koinApp.koin.get<KoinMviRetainedStore<TestState>>(stateQualifier<TestState>())
+
+        // Assert
+        assertSame(customConfig, store.dispatcherConfig)
     }
 }

--- a/yamv-koin/src/test/kotlin/com/ktomek/yamv/koin/KoinMviRetainedStoreDispatcherConfigTest.kt
+++ b/yamv-koin/src/test/kotlin/com/ktomek/yamv/koin/KoinMviRetainedStoreDispatcherConfigTest.kt
@@ -6,9 +6,13 @@ import com.ktomek.yamv.state.CoroutineDispatcherConfig
 import com.ktomek.yamv.state.DefaultCoroutineDispatcherConfig
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.koin.core.KoinApplication
 import org.koin.core.context.stopKoin
@@ -45,7 +49,7 @@ private class TrackingCoroutineDispatcherConfig(
 /**
  * Subclass of [KoinMviRetainedStore] used in tests that require construction via a named config parameter.
  *
- * Since [KoinMviRetainedStore.dispatcherConfig] is public, no extra accessor is needed.
+ * Exposes [dispatcherConfig] publicly so tests can assert on it, since the base class keeps it protected.
  */
 private class InspectableMviRetainedStore<S : State>(
     features: Set<Feature<S>>,
@@ -55,12 +59,23 @@ private class InspectableMviRetainedStore<S : State>(
     features = features,
     defaultState = defaultState,
     dispatcherConfig = config,
-)
+) {
+    public override val dispatcherConfig: CoroutineDispatcherConfig
+        get() = super.dispatcherConfig
+}
 
 class KoinMviRetainedStoreDispatcherConfigTest {
 
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(StandardTestDispatcher())
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
     @AfterEach
     fun tearDown() {
+        Dispatchers.resetMain()
         stopKoin()
     }
 
@@ -138,7 +153,7 @@ class KoinMviRetainedStoreDispatcherConfigTest {
     }
 
     @Test
-    fun `GIVEN mviStore DSL with custom dispatcherConfig WHEN resolved via Koin THEN store has custom dispatcherConfig`() {
+    fun `GIVEN mviStore DSL with custom dispatcherConfig WHEN resolved via Koin THEN store uses custom dispatcherConfig`() {
         // Arrange
         val customConfig = TrackingCoroutineDispatcherConfig()
         val koinModule = module {
@@ -147,9 +162,12 @@ class KoinMviRetainedStoreDispatcherConfigTest {
 
         // Act
         val koinApp = KoinApplication.init().modules(koinModule)
-        val store = koinApp.koin.get<KoinMviRetainedStore<TestState>>(stateQualifier<TestState>())
+        koinApp.koin.get<KoinMviRetainedStore<TestState>>(stateQualifier<TestState>())
 
-        // Assert
-        assertSame(customConfig, store.dispatcherConfig)
+        // Assert — MviRuntime calls provideReducerDispatcher on init using the custom config
+        assertTrue(
+            customConfig.reducerDispatcherCallCount > 0,
+            "Expected reducerDispatcherCallCount > 0 but was ${customConfig.reducerDispatcherCallCount}",
+        )
     }
 }

--- a/yamv-koin/src/test/kotlin/com/ktomek/yamv/koin/KoinMviRetainedStoreDispatcherConfigTest.kt
+++ b/yamv-koin/src/test/kotlin/com/ktomek/yamv/koin/KoinMviRetainedStoreDispatcherConfigTest.kt
@@ -1,0 +1,130 @@
+package com.ktomek.yamv.koin
+
+import com.ktomek.yamv.core.State
+import com.ktomek.yamv.feature.Feature
+import com.ktomek.yamv.state.CoroutineDispatcherConfig
+import com.ktomek.yamv.state.DefaultCoroutineDispatcherConfig
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+private data class TestState(val count: Int = 0) : State
+
+private class TrackingCoroutineDispatcherConfig(
+    private val delegate: CoroutineDispatcher = Dispatchers.Default,
+) : CoroutineDispatcherConfig {
+    var intentionDispatcherCallCount = 0
+    var reducerDispatcherCallCount = 0
+    var featureDispatcherCallCount = 0
+
+    override fun provideIntentionDispatcher(intention: Any?): CoroutineDispatcher {
+        intentionDispatcherCallCount++
+        return delegate
+    }
+
+    override fun provideReducerDispatcher(): CoroutineDispatcher {
+        reducerDispatcherCallCount++
+        return delegate
+    }
+
+    override fun provideFeatureDispatcher(feature: Any): CoroutineDispatcher {
+        featureDispatcherCallCount++
+        return delegate
+    }
+}
+
+/**
+ * Subclass of [KoinMviRetainedStore] that exposes [dispatcherConfig] for assertion in tests.
+ */
+private class InspectableMviRetainedStore<S : State>(
+    features: Set<Feature<S>>,
+    defaultState: S,
+    config: CoroutineDispatcherConfig,
+) : KoinMviRetainedStore<S>(
+    features = features,
+    defaultState = defaultState,
+    dispatcherConfig = config,
+) {
+    fun getDispatcherConfig(): CoroutineDispatcherConfig = dispatcherConfig
+}
+
+class KoinMviRetainedStoreDispatcherConfigTest {
+
+    @Test
+    fun `GIVEN KoinMviRetainedStore with default config WHEN created THEN dispatcherConfig is DefaultCoroutineDispatcherConfig`() {
+        // Arrange & Act
+        val store = InspectableMviRetainedStore(
+            features = emptySet<Feature<TestState>>(),
+            defaultState = TestState(),
+            config = DefaultCoroutineDispatcherConfig(),
+        )
+
+        // Assert
+        assertTrue(store.getDispatcherConfig() is DefaultCoroutineDispatcherConfig)
+    }
+
+    @Test
+    fun `GIVEN KoinMviRetainedStore with custom config WHEN created THEN dispatcherConfig is the custom instance`() {
+        // Arrange
+        val customConfig = TrackingCoroutineDispatcherConfig()
+
+        // Act
+        val store = InspectableMviRetainedStore(
+            features = emptySet<Feature<TestState>>(),
+            defaultState = TestState(),
+            config = customConfig,
+        )
+
+        // Assert
+        assertSame(customConfig, store.getDispatcherConfig())
+    }
+
+    @Test
+    fun `GIVEN KoinMviRetainedStore with custom config WHEN store is created THEN custom config dispatchers are invoked`() = runTest {
+        // Arrange
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val customConfig = TrackingCoroutineDispatcherConfig(delegate = testDispatcher)
+
+        // Act
+        InspectableMviRetainedStore(
+            features = emptySet<Feature<TestState>>(),
+            defaultState = TestState(),
+            config = customConfig,
+        )
+
+        // Assert — MviRuntime calls provideReducerDispatcher on init
+        assertTrue(
+            customConfig.reducerDispatcherCallCount > 0,
+            "Expected reducerDispatcherCallCount > 0 but was ${customConfig.reducerDispatcherCallCount}",
+        )
+    }
+
+    @Test
+    fun `GIVEN KoinMviRetainedStore with custom config WHEN intention dispatched THEN custom intention dispatcher is used`() = runTest {
+        // Arrange
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val customConfig = TrackingCoroutineDispatcherConfig(delegate = testDispatcher)
+        val store = InspectableMviRetainedStore(
+            features = emptySet<Feature<TestState>>(),
+            defaultState = TestState(),
+            config = customConfig,
+        )
+        val callCountBeforeDispatch = customConfig.intentionDispatcherCallCount
+
+        // Act
+        store.dispatch("increment")
+        testScheduler.advanceUntilIdle()
+
+        // Assert
+        assertEquals(
+            callCountBeforeDispatch + 1,
+            customConfig.intentionDispatcherCallCount,
+            "Expected intentionDispatcherCallCount to increase by 1",
+        )
+    }
+}

--- a/yamv-retainer/src/commonMain/kotlin/com/ktomek/yamv/retainer/MviRetainedStore.kt
+++ b/yamv-retainer/src/commonMain/kotlin/com/ktomek/yamv/retainer/MviRetainedStore.kt
@@ -3,6 +3,8 @@ package com.ktomek.yamv.retainer
 import androidx.lifecycle.ViewModel
 import com.ktomek.yamv.core.EffectOutcome
 import com.ktomek.yamv.core.State
+import com.ktomek.yamv.state.CoroutineDispatcherConfig
+import com.ktomek.yamv.state.DefaultCoroutineDispatcherConfig
 import com.ktomek.yamv.state.MviStore
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
@@ -17,6 +19,8 @@ import kotlinx.coroutines.flow.StateFlow
  * @param I The intention type.
  */
 abstract class MviRetainedStore<S : State, I : Any> : ViewModel(), MviStore<S, I> {
+
+    protected open val dispatcherConfig: CoroutineDispatcherConfig = DefaultCoroutineDispatcherConfig()
 
     protected abstract val store: MviStore<S, I>
 


### PR DESCRIPTION
Closes #12

## Summary

- Added `protected open val dispatcherConfig: CoroutineDispatcherConfig = DefaultCoroutineDispatcherConfig()` to `MviRetainedStore`
- `KoinMviRetainedStore` constructor and `mviStore {}` DSL accept optional `dispatcherConfig` parameter
- KSP-generated Hilt stores now pass `dispatcherConfig` to `MviRuntime` (inheriting the `MviRetainedStore` property)
- 5 tests added covering default config, custom config, dispatcher invocation, and Koin DSL resolution

## Test Plan

- [ ] `./gradlew :yamv-koin:testDebugUnitTest --no-daemon` passes (5 tests)
- [ ] `./gradlew detektAll --no-daemon` clean
- [ ] Existing tests unchanged