### PR TITLE
[#14] fix: replace deprecated hiltViewModel() with hilt-lifecycle-viewmodel-compose

### DIFF
--- a/app/hilt/build.gradle
+++ b/app/hilt/build.gradle
@@ -60,7 +60,6 @@ dependencies {
 
     implementation libs.dagger.hilt.core
     implementation libs.dagger.hilt.android
-    implementation libs.androidx.compose.hilt
     ksp libs.dagger.hilt.compiler
     ksp libs.dagger.hilt.android.compiler
     ksp project(':processor-core')

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -70,7 +70,6 @@ androidx-compose-material3 = { module = "androidx.compose.material3:material3" }
 androidx-compose-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "compose" }
 androidx-compose-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
 androidx-compose-navigation = { module = "androidx.navigation:navigation-compose", version = "2.9.7" }
-androidx-compose-hilt = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "compose-hilt" }
 androidx-hilt-lifecycle-viewmodel-compose = { module = "androidx.hilt:hilt-lifecycle-viewmodel-compose", version.ref = "compose-hilt" }
 
 # Dependency Injection lib
@@ -108,7 +107,6 @@ compose = [
     "androidx-compose-meterial",
     "androidx-compose-preview",
     "androidx-compose-navigation",
-    "androidx-compose-hilt",
     "androidx-lifecycle-viewmodel-compose",
 ]
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -71,6 +71,7 @@ androidx-compose-preview = { module = "androidx.compose.ui:ui-tooling-preview", 
 androidx-compose-tooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "compose" }
 androidx-compose-navigation = { module = "androidx.navigation:navigation-compose", version = "2.9.7" }
 androidx-compose-hilt = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "compose-hilt" }
+androidx-hilt-lifecycle-viewmodel-compose = { module = "androidx.hilt:hilt-lifecycle-viewmodel-compose", version.ref = "compose-hilt" }
 
 # Dependency Injection lib
 dagger-hilt-core = { module = "com.google.dagger:hilt-core", version.ref = "hilt" }

--- a/yamv-hilt/build.gradle.kts
+++ b/yamv-hilt/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
     api(project(":yamv-retainer"))
     implementation(libs.dagger.hilt.android)
     ksp(libs.dagger.hilt.android.compiler)
-    implementation(libs.androidx.compose.hilt)
+    implementation(libs.androidx.hilt.lifecycle.viewmodel.compose)
     implementation(libs.androidx.lifecycle.viewmodel.savedstate)
 }
 

--- a/yamv-hilt/src/main/kotlin/com/ktomek/yamv/hilt/HiltMviStore.kt
+++ b/yamv-hilt/src/main/kotlin/com/ktomek/yamv/hilt/HiltMviStore.kt
@@ -1,7 +1,7 @@
 package com.ktomek.yamv.hilt
 
 import androidx.compose.runtime.Composable
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import com.ktomek.yamv.retainer.MviRetainedStore
 
 /**

--- a/yamv-hilt/src/main/kotlin/com/ktomek/yamv/hilt/HiltMviStore.kt
+++ b/yamv-hilt/src/main/kotlin/com/ktomek/yamv/hilt/HiltMviStore.kt
@@ -8,7 +8,7 @@ import com.ktomek.yamv.retainer.MviRetainedStore
  * Returns a Hilt-provided [MviRetainedStore] instance scoped to the current backstack entry.
  *
  * Prefer this over calling [hiltViewModel] directly so call sites stay decoupled from
- * the Hilt navigation API and the type constraint on [MviRetainedStore] is enforced.
+ * the Hilt ViewModel API and the type constraint on [MviRetainedStore] is enforced.
  *
  * Usage:
  * ```


### PR DESCRIPTION
Closes #14

## Summary

- Updated import in `hiltMviStore()` from deprecated `androidx.hilt.navigation.compose.hiltViewModel` to `androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel`
- Added `hilt-lifecycle-viewmodel-compose:1.3.0` to version catalog; removed stale `hilt-navigation-compose` alias and bundle entry
- `hiltMviStore()` public signature unchanged

## Test Plan

- [ ] `./gradlew :yamv-hilt:assembleDebug --no-daemon` — no deprecation warnings
- [ ] `./gradlew detektAll --no-daemon` clean