### PR TITLE
feat: per-feature dispatcher control via HasFeatureDispatcher (#22)

### DIFF
--- a/yamv/src/main/kotlin/com/ktomek/yamv/feature/DefaultFeatureScope.kt
+++ b/yamv/src/main/kotlin/com/ktomek/yamv/feature/DefaultFeatureScope.kt
@@ -4,12 +4,14 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlin.coroutines.ContinuationInterceptor
 
 /**
  * Default implementation of [HasFeatureScope] for use with interface delegation.
  *
  * Creates a [CoroutineScope] backed by a [SupervisorJob], using [dispatcher] if provided
- * or [Dispatchers.Default] otherwise.
+ * or [Dispatchers.Default] otherwise. The [featureDispatcher] is extracted from the scope's
+ * coroutine context.
  *
  * @param dispatcher Optional dispatcher for the scope. Defaults to [Dispatchers.Default].
  */
@@ -18,4 +20,8 @@ class DefaultFeatureScope(
 ) : HasFeatureScope {
     override val featureScope: CoroutineScope =
         CoroutineScope(SupervisorJob() + (dispatcher ?: Dispatchers.Default))
+
+    override val featureDispatcher: CoroutineDispatcher
+        get() = featureScope.coroutineContext[ContinuationInterceptor] as? CoroutineDispatcher
+            ?: Dispatchers.Default
 }

--- a/yamv/src/main/kotlin/com/ktomek/yamv/feature/HasFeatureDispatcher.kt
+++ b/yamv/src/main/kotlin/com/ktomek/yamv/feature/HasFeatureDispatcher.kt
@@ -1,0 +1,24 @@
+package com.ktomek.yamv.feature
+
+import kotlinx.coroutines.CoroutineDispatcher
+
+/**
+ * Opt-in interface for features that need to run on a specific [CoroutineDispatcher].
+ *
+ * When a feature implements this interface, [FeatureRouter][com.ktomek.yamv.intention.FeatureRouter]
+ * launches the feature on [featureDispatcher] instead of the dispatcher provided by
+ * [CoroutineDispatcherConfig][com.ktomek.yamv.state.CoroutineDispatcherConfig].
+ *
+ * ```kotlin
+ * class NetworkFeature : TypedFeature<MyState, FetchData>, HasFeatureDispatcher {
+ *     override val featureDispatcher = Dispatchers.IO
+ *     // ...
+ * }
+ * ```
+ *
+ * [HasFeatureScope] extends this interface, so features with a custom scope automatically
+ * expose the scope's dispatcher.
+ */
+interface HasFeatureDispatcher {
+    val featureDispatcher: CoroutineDispatcher
+}

--- a/yamv/src/main/kotlin/com/ktomek/yamv/feature/HasFeatureScope.kt
+++ b/yamv/src/main/kotlin/com/ktomek/yamv/feature/HasFeatureScope.kt
@@ -1,9 +1,16 @@
 package com.ktomek.yamv.feature
 
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlin.coroutines.ContinuationInterceptor
 
 /**
  * Opt-in interface for features that need a coroutine scope tied to the feature's lifetime.
+ *
+ * Extends [HasFeatureDispatcher] — the dispatcher is extracted from [featureScope]'s context
+ * by default, so [FeatureRouter][com.ktomek.yamv.intention.FeatureRouter] launches the feature
+ * on the scope's dispatcher automatically.
  *
  * Implement via delegation to [DefaultFeatureScope]:
  * ```kotlin
@@ -17,6 +24,10 @@ import kotlinx.coroutines.CoroutineScope
  *
  * The scope is automatically cancelled when `MviRuntime.clear()` is called.
  */
-interface HasFeatureScope {
+interface HasFeatureScope : HasFeatureDispatcher {
     val featureScope: CoroutineScope
+
+    override val featureDispatcher: CoroutineDispatcher
+        get() = featureScope.coroutineContext[ContinuationInterceptor] as? CoroutineDispatcher
+            ?: Dispatchers.Default
 }

--- a/yamv/src/main/kotlin/com/ktomek/yamv/feature/HasFeatureScope.kt
+++ b/yamv/src/main/kotlin/com/ktomek/yamv/feature/HasFeatureScope.kt
@@ -1,16 +1,12 @@
 package com.ktomek.yamv.feature
 
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlin.coroutines.ContinuationInterceptor
 
 /**
  * Opt-in interface for features that need a coroutine scope tied to the feature's lifetime.
  *
- * Extends [HasFeatureDispatcher] — the dispatcher is extracted from [featureScope]'s context
- * by default, so [FeatureRouter][com.ktomek.yamv.intention.FeatureRouter] launches the feature
- * on the scope's dispatcher automatically.
+ * Extends [HasFeatureDispatcher] — implementations should derive [featureDispatcher] from
+ * [featureScope]'s context. See [DefaultFeatureScope] for the standard implementation.
  *
  * Implement via delegation to [DefaultFeatureScope]:
  * ```kotlin
@@ -26,8 +22,4 @@ import kotlin.coroutines.ContinuationInterceptor
  */
 interface HasFeatureScope : HasFeatureDispatcher {
     val featureScope: CoroutineScope
-
-    override val featureDispatcher: CoroutineDispatcher
-        get() = featureScope.coroutineContext[ContinuationInterceptor] as? CoroutineDispatcher
-            ?: Dispatchers.Default
 }

--- a/yamv/src/main/kotlin/com/ktomek/yamv/intention/FeatureRouter.kt
+++ b/yamv/src/main/kotlin/com/ktomek/yamv/intention/FeatureRouter.kt
@@ -5,6 +5,7 @@ import com.ktomek.yamv.core.State
 import com.ktomek.yamv.feature.Feature
 import com.ktomek.yamv.feature.Feature.FlowFeature
 import com.ktomek.yamv.feature.Feature.FlowUnitFeature
+import com.ktomek.yamv.feature.HasFeatureDispatcher
 import com.ktomek.yamv.feature.HasFeatureScope
 import com.ktomek.yamv.feature.TypedFeatureHolder
 import com.ktomek.yamv.logging.Yamv
@@ -71,7 +72,9 @@ internal class FeatureRouter<S : State>(
 
         featureJobs = features.map { feature ->
             val f = (feature as? TypedFeatureHolder)?.feature ?: feature
-            scope.launch(dispatcherConfig.provideFeatureDispatcher(f)) {
+            val dispatcher = (f as? HasFeatureDispatcher)?.featureDispatcher
+                ?: dispatcherConfig.provideFeatureDispatcher(f)
+            scope.launch(dispatcher) {
                 processFeature(feature)
             }
         }

--- a/yamv/src/test/kotlin/com/ktomek/yamv/feature/HasFeatureDispatcherTest.kt
+++ b/yamv/src/test/kotlin/com/ktomek/yamv/feature/HasFeatureDispatcherTest.kt
@@ -1,0 +1,36 @@
+package com.ktomek.yamv.feature
+
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.StandardTestDispatcher
+import org.junit.jupiter.api.Test
+
+class HasFeatureDispatcherTest {
+
+    @Test
+    fun `DefaultFeatureScope exposes scope dispatcher as featureDispatcher`() {
+        val dispatcher = StandardTestDispatcher()
+        val scope = DefaultFeatureScope(dispatcher)
+
+        assertThat(scope.featureDispatcher).isSameInstanceAs(dispatcher)
+    }
+
+    @Test
+    fun `DefaultFeatureScope without explicit dispatcher returns Default`() {
+        val scope = DefaultFeatureScope()
+
+        assertThat(scope.featureDispatcher).isEqualTo(Dispatchers.Default)
+    }
+
+    @Test
+    fun `HasFeatureScope default implementation extracts dispatcher from scope`() {
+        val dispatcher = StandardTestDispatcher()
+        val feature = object : HasFeatureScope {
+            override val featureScope = kotlinx.coroutines.CoroutineScope(
+                kotlinx.coroutines.SupervisorJob() + dispatcher
+            )
+        }
+
+        assertThat(feature.featureDispatcher).isSameInstanceAs(dispatcher)
+    }
+}

--- a/yamv/src/test/kotlin/com/ktomek/yamv/feature/HasFeatureDispatcherTest.kt
+++ b/yamv/src/test/kotlin/com/ktomek/yamv/feature/HasFeatureDispatcherTest.kt
@@ -22,15 +22,4 @@ class HasFeatureDispatcherTest {
         assertThat(scope.featureDispatcher).isEqualTo(Dispatchers.Default)
     }
 
-    @Test
-    fun `HasFeatureScope default implementation extracts dispatcher from scope`() {
-        val dispatcher = StandardTestDispatcher()
-        val feature = object : HasFeatureScope {
-            override val featureScope = kotlinx.coroutines.CoroutineScope(
-                kotlinx.coroutines.SupervisorJob() + dispatcher
-            )
-        }
-
-        assertThat(feature.featureDispatcher).isSameInstanceAs(dispatcher)
-    }
 }

--- a/yamv/src/test/kotlin/com/ktomek/yamv/intention/FeatureRouterDispatcherTest.kt
+++ b/yamv/src/test/kotlin/com/ktomek/yamv/intention/FeatureRouterDispatcherTest.kt
@@ -1,0 +1,102 @@
+package com.ktomek.yamv.intention
+
+import com.google.common.truth.Truth.assertThat
+import com.ktomek.yamv.core.Outcome
+import com.ktomek.yamv.core.State
+import com.ktomek.yamv.core.StateOutcome
+import com.ktomek.yamv.feature.DefaultFeatureScope
+import com.ktomek.yamv.feature.Feature
+import com.ktomek.yamv.feature.HasFeatureDispatcher
+import com.ktomek.yamv.feature.HasFeatureScope
+import com.ktomek.yamv.state.CoroutineDispatcherConfig
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import kotlin.coroutines.ContinuationInterceptor
+
+private data class DispatcherTestState(val dispatcher: String = "") : State
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class FeatureRouterDispatcherTest {
+
+    @Test
+    fun `feature with HasFeatureDispatcher runs on feature dispatcher`() = runTest {
+        val featureDispatcher = StandardTestDispatcher(testScheduler, name = "feature")
+        val configDispatcher = StandardTestDispatcher(testScheduler, name = "config")
+        var capturedDispatcher: CoroutineDispatcher? = null
+
+        val feature = object : Feature.FlowFeature<DispatcherTestState>, HasFeatureDispatcher {
+            override val featureDispatcher = featureDispatcher
+            override fun invoke(intentions: Flow<Any>): Flow<Outcome<DispatcherTestState>> =
+                channelFlow {
+                    capturedDispatcher =
+                        coroutineContext[ContinuationInterceptor] as? CoroutineDispatcher
+                    intentions.collect { send(StateOutcome { it }) }
+                }
+        }
+
+        val router = FeatureRouter(features = setOf(feature))
+        router.initialize(this, testDispatcherConfig(configDispatcher))
+        testScheduler.advanceUntilIdle()
+
+        assertThat(capturedDispatcher).isSameInstanceAs(featureDispatcher)
+        router.shutdown()
+    }
+
+    @Test
+    fun `feature with HasFeatureScope runs on scope dispatcher`() = runTest {
+        val scopeDispatcher = StandardTestDispatcher(testScheduler, name = "scope")
+        val configDispatcher = StandardTestDispatcher(testScheduler, name = "config")
+        var capturedDispatcher: CoroutineDispatcher? = null
+
+        val feature = object :
+            Feature.FlowFeature<DispatcherTestState>,
+            HasFeatureScope by DefaultFeatureScope(scopeDispatcher) {
+            override fun invoke(intentions: Flow<Any>): Flow<Outcome<DispatcherTestState>> =
+                channelFlow {
+                    capturedDispatcher =
+                        coroutineContext[ContinuationInterceptor] as? CoroutineDispatcher
+                    intentions.collect { send(StateOutcome { it }) }
+                }
+        }
+
+        val router = FeatureRouter(features = setOf(feature))
+        router.initialize(this, testDispatcherConfig(configDispatcher))
+        testScheduler.advanceUntilIdle()
+
+        assertThat(capturedDispatcher).isSameInstanceAs(scopeDispatcher)
+        router.shutdown()
+    }
+
+    @Test
+    fun `feature without HasFeatureDispatcher falls back to config`() = runTest {
+        val configDispatcher = StandardTestDispatcher(testScheduler, name = "config")
+        var capturedDispatcher: CoroutineDispatcher? = null
+
+        val feature = Feature.FlowFeature<DispatcherTestState> { intentions ->
+            channelFlow {
+                capturedDispatcher =
+                    coroutineContext[ContinuationInterceptor] as? CoroutineDispatcher
+                intentions.collect { send(StateOutcome { it }) }
+            }
+        }
+
+        val router = FeatureRouter(features = setOf(feature))
+        router.initialize(this, testDispatcherConfig(configDispatcher))
+        testScheduler.advanceUntilIdle()
+
+        assertThat(capturedDispatcher).isSameInstanceAs(configDispatcher)
+        router.shutdown()
+    }
+}
+
+private fun testDispatcherConfig(dispatcher: CoroutineDispatcher) =
+    object : CoroutineDispatcherConfig {
+        override fun provideIntentionDispatcher(intention: Any?) = dispatcher
+        override fun provideReducerDispatcher() = dispatcher
+        override fun provideFeatureDispatcher(feature: Any) = dispatcher
+    }


### PR DESCRIPTION
## Summary

- New `HasFeatureDispatcher` interface lets features declare their own `CoroutineDispatcher`
- `HasFeatureScope` now extends `HasFeatureDispatcher` with default implementation extracting dispatcher from scope context
- `FeatureRouter` checks `HasFeatureDispatcher` before falling back to `CoroutineDispatcherConfig`
- Non-breaking: existing features unchanged, `DefaultFeatureScope` gains `featureDispatcher` automatically

**Precedence:** feature interface > config > `Dispatchers.Default`

Closes #22

## Test plan

- [x] Feature with `HasFeatureDispatcher` runs on declared dispatcher
- [x] Feature with `HasFeatureScope` runs on scope's dispatcher
- [x] Feature without either falls back to config dispatcher
- [x] `DefaultFeatureScope` exposes correct `featureDispatcher`
- [x] All existing tests pass
- [x] Detekt clean