### PR TITLE
chore: fix copyright holder name in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -176,7 +176,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2024 Krzysztof Tomek
+   Copyright 2024 Tomasz Kaszkowiak
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Full documentation: **[ktomek.github.io/yamv](https://ktomek.github.io/yamv)**
 ## License
 
 ```
-Copyright 2024 Krzysztof Tomek
+Copyright 2024 Tomasz Kaszkowiak
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Summary

- Fix copyright holder name from placeholder to "Tomasz Kaszkowiak" in LICENSE and README