### PR TITLE
feat: @AutoDispatcherConfig for zero-boilerplate dispatcher injection (#26)

### DIFF
--- a/core/src/main/kotlin/com/ktomek/yamv/annotations/AutoDispatcherConfig.kt
+++ b/core/src/main/kotlin/com/ktomek/yamv/annotations/AutoDispatcherConfig.kt
@@ -1,0 +1,29 @@
+package com.ktomek.yamv.annotations
+
+import com.ktomek.yamv.core.State
+import kotlin.reflect.KClass
+
+/**
+ * Annotate a [com.ktomek.yamv.state.CoroutineDispatcherConfig] implementation to have the KSP
+ * processor generate a Dagger module that provides it automatically.
+ *
+ * - **No arguments** — global default for all states without a specific override
+ * - **One state** — per-state override
+ * - **Multiple states** — same config for several states
+ *
+ * Precedence: per-state > global default > [com.ktomek.yamv.state.DefaultCoroutineDispatcherConfig]
+ *
+ * ```kotlin
+ * @AutoDispatcherConfig
+ * class IoDispatcherConfig : CoroutineDispatcherConfig { ... }
+ *
+ * @AutoDispatcherConfig(CounterState::class)
+ * class CounterDispatcherConfig : CoroutineDispatcherConfig { ... }
+ *
+ * @AutoDispatcherConfig(TimerState::class, AnimationState::class)
+ * class SharedConfig : CoroutineDispatcherConfig { ... }
+ * ```
+ */
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.SOURCE)
+annotation class AutoDispatcherConfig(vararg val value: KClass<out State>)

--- a/processor-core/src/main/kotlin/com/ktomek/yamv/processor/core/AutoDispatcherConfigDiscovery.kt
+++ b/processor-core/src/main/kotlin/com/ktomek/yamv/processor/core/AutoDispatcherConfigDiscovery.kt
@@ -1,0 +1,17 @@
+package com.ktomek.yamv.processor.core
+
+import com.google.devtools.ksp.processing.Resolver
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.validate
+import com.ktomek.yamv.annotations.AutoDispatcherConfig
+
+object AutoDispatcherConfigDiscovery {
+
+    private val annotationFqn = AutoDispatcherConfig::class.qualifiedName!!
+
+    fun findAnnotatedClasses(resolver: Resolver): Sequence<KSClassDeclaration> =
+        resolver
+            .getSymbolsWithAnnotation(annotationFqn)
+            .filterIsInstance<KSClassDeclaration>()
+            .filter { it.validate() }
+}

--- a/processor-hilt/src/main/kotlin/com/ktomek/yamv/processor/YamvProcessor.kt
+++ b/processor-hilt/src/main/kotlin/com/ktomek/yamv/processor/YamvProcessor.kt
@@ -7,7 +7,9 @@ import com.google.devtools.ksp.processing.SymbolProcessor
 import com.google.devtools.ksp.processing.SymbolProcessorEnvironment
 import com.google.devtools.ksp.processing.SymbolProcessorProvider
 import com.google.devtools.ksp.symbol.KSAnnotated
+import com.ktomek.yamv.processor.core.AutoDispatcherConfigDiscovery
 import com.ktomek.yamv.processor.core.AutoStateDiscovery
+import com.ktomek.yamv.processor.hilt.DispatcherConfigModuleGenerator
 import com.ktomek.yamv.processor.hilt.FeatureFilter
 import com.ktomek.yamv.processor.hilt.FeaturesModuleGenerator
 import com.ktomek.yamv.processor.hilt.ViewModelGenerator
@@ -31,6 +33,14 @@ class YamvProcessor(
             viewModelGenerator.generate(stateClass)
             val stateFeatures = featureFilter.forState(stateClass, allFeatures)
             featuresModuleGenerator.generate(stateClass, stateFeatures)
+        }
+
+        val dispatcherConfigs = AutoDispatcherConfigDiscovery.findAnnotatedClasses(resolver).toList()
+        if (dispatcherConfigs.isNotEmpty()) {
+            val dispatcherConfigGenerator = DispatcherConfigModuleGenerator(codeGenerator)
+            dispatcherConfigs.forEach { configClass ->
+                dispatcherConfigGenerator.generate(configClass)
+            }
         }
 
         return emptyList()

--- a/processor-hilt/src/main/kotlin/com/ktomek/yamv/processor/hilt/DispatcherConfigModuleGenerator.kt
+++ b/processor-hilt/src/main/kotlin/com/ktomek/yamv/processor/hilt/DispatcherConfigModuleGenerator.kt
@@ -1,0 +1,114 @@
+package com.ktomek.yamv.processor.hilt
+
+import com.google.devtools.ksp.processing.CodeGenerator
+import com.google.devtools.ksp.processing.Dependencies
+import com.google.devtools.ksp.symbol.KSClassDeclaration
+import com.google.devtools.ksp.symbol.KSType
+import com.squareup.kotlinpoet.AnnotationSpec
+import com.squareup.kotlinpoet.FileSpec
+import com.squareup.kotlinpoet.FunSpec
+import com.squareup.kotlinpoet.TypeSpec
+import com.squareup.kotlinpoet.ksp.toClassName
+import com.squareup.kotlinpoet.ksp.writeTo
+
+/**
+ * Generates a Dagger `@Module` that provides a [CoroutineDispatcherConfig] implementation
+ * annotated with `@AutoDispatcherConfig`.
+ *
+ * - **No state args (global default):**
+ * ```kotlin
+ * @Module
+ * @InstallIn(ViewModelComponent::class)
+ * object IoDispatcherConfigModule {
+ *     @Provides
+ *     fun provideDefault(): CoroutineDispatcherConfig = IoDispatcherConfig()
+ * }
+ * ```
+ *
+ * - **Per-state / multi-state:**
+ * ```kotlin
+ * @Module
+ * @InstallIn(ViewModelComponent::class)
+ * object CounterDispatcherConfigModule {
+ *     @Provides @MviDispatcherConfig(CounterState::class)
+ *     fun provideForCounterState(): CoroutineDispatcherConfig = CounterDispatcherConfig()
+ * }
+ * ```
+ */
+internal class DispatcherConfigModuleGenerator(private val codeGenerator: CodeGenerator) {
+
+    fun generate(classDecl: KSClassDeclaration) {
+        val configClassName = classDecl.toClassName()
+        val moduleName = "${configClassName.simpleName}Module"
+
+        val annotation = classDecl.annotations
+            .first { it.shortName.asString() == "AutoDispatcherConfig" }
+
+        @Suppress("UNCHECKED_CAST")
+        val stateTypes = annotation.arguments
+            .firstOrNull { it.name?.asString() == "value" }
+            ?.value as? List<KSType> ?: emptyList()
+
+        val moduleSpec = if (stateTypes.isEmpty()) {
+            buildGlobalModule(moduleName, configClassName)
+        } else {
+            buildPerStateModule(moduleName, configClassName, stateTypes)
+        }
+
+        FileSpec.builder(configClassName.packageName, moduleName)
+            .addType(moduleSpec)
+            .build()
+            .writeTo(codeGenerator, Dependencies(false))
+    }
+
+    private fun buildGlobalModule(
+        moduleName: String,
+        configClassName: com.squareup.kotlinpoet.ClassName,
+    ): TypeSpec = TypeSpec.objectBuilder(moduleName)
+        .addAnnotation(HiltClassNames.Module)
+        .addAnnotation(buildInstallInAnnotation())
+        .addFunction(
+            FunSpec.builder("provideDefault")
+                .addAnnotation(HiltClassNames.Provides)
+                .returns(YamvClassNames.CoroutineDispatcherConfig)
+                .addStatement("return %T()", configClassName)
+                .build()
+        )
+        .build()
+
+    private fun buildPerStateModule(
+        moduleName: String,
+        configClassName: com.squareup.kotlinpoet.ClassName,
+        stateTypes: List<KSType>,
+    ): TypeSpec {
+        val builder = TypeSpec.objectBuilder(moduleName)
+            .addAnnotation(HiltClassNames.Module)
+            .addAnnotation(buildInstallInAnnotation())
+
+        stateTypes.forEach { stateType ->
+            val stateClassDecl = stateType.declaration as KSClassDeclaration
+            val stateClassName = stateClassDecl.toClassName()
+            val stateName = stateClassName.simpleName
+
+            builder.addFunction(
+                FunSpec.builder("provideFor$stateName")
+                    .addAnnotation(HiltClassNames.Provides)
+                    .addAnnotation(
+                        AnnotationSpec.builder(HiltClassNames.MviDispatcherConfig)
+                            .addMember("%T::class", stateClassName)
+                            .build()
+                    )
+                    .returns(YamvClassNames.CoroutineDispatcherConfig)
+                    .addStatement("return %T()", configClassName)
+                    .build()
+            )
+        }
+
+        return builder.build()
+    }
+
+    private fun buildInstallInAnnotation(): AnnotationSpec =
+        AnnotationSpec.builder(HiltClassNames.InstallIn)
+            .addMember("%T::class", HiltClassNames.ViewModelComponent)
+            .build()
+}

--- a/processor-hilt/src/main/kotlin/com/ktomek/yamv/processor/hilt/ViewModelGenerator.kt
+++ b/processor-hilt/src/main/kotlin/com/ktomek/yamv/processor/hilt/ViewModelGenerator.kt
@@ -25,10 +25,11 @@ import com.squareup.kotlinpoet.ksp.writeTo
  * @HiltViewModel
  * class CounterStateStore @Inject constructor(
  *     features: Set<@JvmSuppressWildcards Feature<CounterState>>,
+ *     defaultConfig: Optional<CoroutineDispatcherConfig>,
  *     @MviDispatcherConfig(CounterState::class) optionalDispatcherConfig: Optional<CoroutineDispatcherConfig>,
  * ) : MviRetainedStore<CounterState, Any>() {
  *     override val dispatcherConfig: CoroutineDispatcherConfig =
- *         optionalDispatcherConfig.orElseGet { DefaultCoroutineDispatcherConfig() }
+ *         optionalDispatcherConfig.orElseGet { defaultConfig.orElseGet { DefaultCoroutineDispatcherConfig() } }
  *     override val store: MviStore<CounterState, Any> = MviRuntime(
  *         features = features,
  *         defaultState = CounterState(),
@@ -87,6 +88,10 @@ internal class ViewModelGenerator(private val codeGenerator: CodeGenerator) {
                 )
             )
             .addParameter(
+                "defaultConfig",
+                HiltClassNames.Optional.parameterizedBy(YamvClassNames.CoroutineDispatcherConfig),
+            )
+            .addParameter(
                 com.squareup.kotlinpoet.ParameterSpec.builder(
                     "optionalDispatcherConfig",
                     HiltClassNames.Optional.parameterizedBy(YamvClassNames.CoroutineDispatcherConfig),
@@ -104,7 +109,7 @@ internal class ViewModelGenerator(private val codeGenerator: CodeGenerator) {
         PropertySpec.builder("dispatcherConfig", YamvClassNames.CoroutineDispatcherConfig)
             .addModifiers(KModifier.OVERRIDE)
             .initializer(
-                "optionalDispatcherConfig.orElseGet·{·%T()·}",
+                "optionalDispatcherConfig.orElseGet·{·defaultConfig.orElseGet·{·%T()·}·}",
                 YamvClassNames.DefaultCoroutineDispatcherConfig,
             )
             .build()

--- a/site-docs/architecture.md
+++ b/site-docs/architecture.md
@@ -106,16 +106,25 @@ class NetworkFeature : TypedFeature<MyState, FetchData>, HasFeatureDispatcher {
 
 Features with `HasFeatureScope` (via `DefaultFeatureScope`) automatically expose the scope's dispatcher.
 
-**Per-state config (Hilt):** Use the `@MviDispatcherConfig` qualifier to inject a custom config per state type:
+**Per-state config (Hilt):** Annotate a `CoroutineDispatcherConfig` class with `@AutoDispatcherConfig` to have the Dagger module generated automatically:
 
 ```kotlin
-@Module
-@InstallIn(ViewModelComponent::class)
-object MyDispatcherModule {
-    @Provides @MviDispatcherConfig(CounterState::class)
-    fun provide(): CoroutineDispatcherConfig = CustomDispatcherConfig()
-}
+// Global default — applies to all states without a specific override
+@AutoDispatcherConfig
+class IoDispatcherConfig : CoroutineDispatcherConfig { ... }
+
+// Per-state — overrides default for CounterState only
+@AutoDispatcherConfig(CounterState::class)
+class CounterDispatcherConfig : CoroutineDispatcherConfig { ... }
+
+// Multi-state — same config for several states
+@AutoDispatcherConfig(TimerState::class, AnimationState::class)
+class SharedConfig : CoroutineDispatcherConfig { ... }
 ```
+
+Precedence: per-state > global default > `DefaultCoroutineDispatcherConfig()`
+
+See [Code Generation — @AutoDispatcherConfig](code-generation.md#autodispatcherconfig) for generated output details.
 
 !!! info "Subscription safety"
     `FeatureRouter` uses `CompletableDeferred` to ensure all features are subscribed to the intention `SharedFlow` before the first intention is dispatched. This prevents race conditions at startup.

--- a/site-docs/code-generation.md
+++ b/site-docs/code-generation.md
@@ -16,11 +16,12 @@ data class CounterState(val count: Int = 0) : State
 @HiltViewModel
 class CounterStateStore @Inject constructor(
     features: Set<@JvmSuppressWildcards Feature<CounterState>>,
+    defaultConfig: Optional<CoroutineDispatcherConfig>,
     @MviDispatcherConfig(CounterState::class)
     optionalDispatcherConfig: Optional<CoroutineDispatcherConfig>,
 ) : MviRetainedStore<CounterState, Any>() {
     override val dispatcherConfig: CoroutineDispatcherConfig =
-        optionalDispatcherConfig.orElseGet { DefaultCoroutineDispatcherConfig() }
+        optionalDispatcherConfig.orElseGet { defaultConfig.orElseGet { DefaultCoroutineDispatcherConfig() } }
     override val store: MviStore<CounterState, Any> = MviRuntime(
         features = features,
         defaultState = CounterState(),
@@ -78,12 +79,59 @@ object CounterFeatures {
 }
 ```
 
+## @AutoDispatcherConfig
+
+Annotate a `CoroutineDispatcherConfig` implementation to auto-generate a Dagger module — no manual `@Module` + `@Provides` needed:
+
+```kotlin
+// Global default — applies to all states without a specific override
+@AutoDispatcherConfig
+class IoDispatcherConfig : CoroutineDispatcherConfig {
+    override fun provideIntentionDispatcher(intention: Any?) = Dispatchers.Main
+    override fun provideReducerDispatcher() = Dispatchers.Main
+    override fun provideFeatureDispatcher(feature: Any) = Dispatchers.IO
+}
+```
+
+**Generated** `IoDispatcherConfigModule.kt`:
+```kotlin
+@Module
+@InstallIn(ViewModelComponent::class)
+object IoDispatcherConfigModule {
+    @Provides
+    fun provideDefault(): CoroutineDispatcherConfig = IoDispatcherConfig()
+}
+```
+
+For per-state or multi-state configs, specify the state classes:
+
+```kotlin
+@AutoDispatcherConfig(CounterState::class)
+class CounterConfig : CoroutineDispatcherConfig { ... }
+
+@AutoDispatcherConfig(TimerState::class, AnimationState::class)
+class SharedConfig : CoroutineDispatcherConfig { ... }
+```
+
+**Generated** (per-state):
+```kotlin
+@Module
+@InstallIn(ViewModelComponent::class)
+object CounterConfigModule {
+    @Provides @MviDispatcherConfig(CounterState::class)
+    fun provideForCounterState(): CoroutineDispatcherConfig = CounterConfig()
+}
+```
+
+Precedence: per-state > global default > `DefaultCoroutineDispatcherConfig()`
+
 ## Processor Modules
 
 | Module | Annotation | Output |
 |--------|-----------|--------|
 | `processor-hilt` | `@AutoState` | `{Name}Store` (`@HiltViewModel`) |
 | `processor-hilt` | `@AutoFeature` | `{Name}FeaturesModule` (Hilt `@Module`) |
+| `processor-hilt` | `@AutoDispatcherConfig` | `{Name}Module` (Dagger `@Module` with `@Provides`) |
 
 ## Without Code Generation
 

--- a/yamv-hilt/src/main/kotlin/com/ktomek/yamv/hilt/YamvDispatcherModule.kt
+++ b/yamv-hilt/src/main/kotlin/com/ktomek/yamv/hilt/YamvDispatcherModule.kt
@@ -1,0 +1,24 @@
+package com.ktomek.yamv.hilt
+
+import com.ktomek.yamv.state.CoroutineDispatcherConfig
+import dagger.BindsOptionalOf
+import dagger.Module
+import dagger.hilt.InstallIn
+import dagger.hilt.android.components.ViewModelComponent
+
+/**
+ * Declares an optional unqualified [CoroutineDispatcherConfig] binding.
+ *
+ * This enables the generated `*Store` classes to accept an `Optional<CoroutineDispatcherConfig>`
+ * as a global default, which is overridden by per-state bindings qualified with
+ * [MviDispatcherConfig].
+ *
+ * Provide a binding via [@AutoDispatcherConfig][com.ktomek.yamv.annotations.AutoDispatcherConfig]
+ * (no arguments) or manually with an unqualified `@Provides`.
+ */
+@Module
+@InstallIn(ViewModelComponent::class)
+interface YamvDispatcherModule {
+    @BindsOptionalOf
+    fun bindDefaultDispatcherConfig(): CoroutineDispatcherConfig
+}


### PR DESCRIPTION
## Summary

- New `@AutoDispatcherConfig` annotation — annotate a `CoroutineDispatcherConfig` class to auto-generate the Dagger module
- Three modes: global default (no args), per-state, multi-state
- Precedence: per-state > global default > `DefaultCoroutineDispatcherConfig()`
- New `YamvDispatcherModule` in `:yamv-hilt` with `@BindsOptionalOf` for unqualified default
- Generated `*Store` now has two `Optional` params (unqualified default + `@MviDispatcherConfig`-qualified)

### Usage

```kotlin
@AutoDispatcherConfig
class IoConfig : CoroutineDispatcherConfig { ... }

@AutoDispatcherConfig(CounterState::class)
class CounterConfig : CoroutineDispatcherConfig { ... }

@AutoDispatcherConfig(TimerState::class, AnimationState::class)
class SharedConfig : CoroutineDispatcherConfig { ... }
```

Closes #26

## Test plan

- [x] Build succeeds with KSP generation
- [x] Generated `CounterStateStore` has two Optional params with precedence chain
- [x] Generated `*FeaturesModule` unchanged (per-state `@BindsOptionalOf` still present)
- [x] Detekt clean