### PR TITLE
feat: State → UiState mapping with distinctUntilChanged (#39)

### DIFF
--- a/app/hilt/src/main/kotlin/com/ktomek/yamv/MainActivity.kt
+++ b/app/hilt/src/main/kotlin/com/ktomek/yamv/MainActivity.kt
@@ -3,11 +3,23 @@ package com.ktomek.yamv
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
+import androidx.compose.material3.Button
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import com.ktomek.yamv.counter.CounterScreen
+import com.ktomek.yamv.profile.ProfileScreen
 import com.ktomek.yamv.ui.theme.YamvTheme
 import dagger.hilt.android.AndroidEntryPoint
 
@@ -22,9 +34,33 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colors.background
                 ) {
-                    CounterScreen()
+                    DemoHost()
                 }
             }
+        }
+    }
+}
+
+private enum class Demo { COUNTER, PROFILE }
+
+@Composable
+private fun DemoHost() {
+    var demo by rememberSaveable { mutableStateOf(Demo.COUNTER) }
+    Column(modifier = Modifier.fillMaxSize()) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceEvenly,
+        ) {
+            Button(onClick = { demo = Demo.COUNTER }, modifier = Modifier.weight(1f)) {
+                Text("Counter")
+            }
+            Button(onClick = { demo = Demo.PROFILE }, modifier = Modifier.weight(1f)) {
+                Text("Profile (UiState)")
+            }
+        }
+        when (demo) {
+            Demo.COUNTER -> CounterScreen()
+            Demo.PROFILE -> ProfileScreen()
         }
     }
 }

--- a/app/hilt/src/main/kotlin/com/ktomek/yamv/profile/ProfileScreen.kt
+++ b/app/hilt/src/main/kotlin/com/ktomek/yamv/profile/ProfileScreen.kt
@@ -1,0 +1,101 @@
+package com.ktomek.yamv.profile
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.ktomek.yamv.hilt.hiltMviStore
+import com.ktomek.yamv.profile.logic.SaveProfileIntention
+import com.ktomek.yamv.profile.logic.UpdateEmailIntention
+import com.ktomek.yamv.profile.logic.UpdateNameIntention
+import com.ktomek.yamv.profile.logic.state.ProfileState
+import com.ktomek.yamv.profile.logic.state.ProfileStateStore
+import com.ktomek.yamv.profile.logic.uistate.ProfileUiState
+import com.ktomek.yamv.state.uiState
+
+/**
+ * Demonstrates State -> UiState projection.
+ *
+ * Edit the fields and press Save. The two counters make the benefit visible:
+ * pressing Save churns internal bookkeeping (`saveAttempts`) several times, so the
+ * raw-state probe recomposes on every tick, while the projected form recomposes
+ * only for the two `isSaving` transitions the UI actually cares about.
+ */
+@Composable
+fun ProfileScreen(
+    store: ProfileStateStore = hiltMviStore(),
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(GAP),
+        verticalArrangement = Arrangement.spacedBy(GAP),
+    ) {
+        Text("Edit your profile, then press Save and watch the two counters below.")
+        ProjectedProfileForm(store)
+        Spacer(Modifier.height(GAP))
+        RawStateProbe(store)
+    }
+}
+
+/** Collects the UiState projection — recomposes only when the projected values change. */
+@Composable
+private fun ProjectedProfileForm(store: ProfileStateStore) {
+    val scope = rememberCoroutineScope()
+    val ui by remember(store, scope) {
+        store.uiState<ProfileState, ProfileUiState>(scope)
+    }.collectAsState()
+    val recompositions = countRecompositions()
+
+    OutlinedTextField(
+        value = ui.name,
+        onValueChange = { store.dispatch(UpdateNameIntention(it)) },
+        label = { Text("Name") },
+        modifier = Modifier.fillMaxWidth(),
+    )
+    OutlinedTextField(
+        value = ui.email,
+        onValueChange = { store.dispatch(UpdateEmailIntention(it)) },
+        label = { Text("Email") },
+        modifier = Modifier.fillMaxWidth(),
+    )
+    Button(
+        onClick = { store.dispatch(SaveProfileIntention) },
+        enabled = ui.canSave,
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Text(if (ui.isSaving) "Saving…" else "Save")
+    }
+    Text("Projected (uiState) recompositions: $recompositions")
+}
+
+/** Collects the FULL state — recomposes on every emission, including internal bookkeeping churn. */
+@Composable
+private fun RawStateProbe(store: ProfileStateStore) {
+    val state by store.state.collectAsState()
+    val recompositions = countRecompositions()
+    Text("Raw (store.state) recompositions: $recompositions")
+    Text("Internal saveAttempts (hidden from UiState): ${state.saveAttempts}")
+}
+
+/** Plain (non-snapshot) recomposition counter — increments once per recomposition. */
+@Composable
+private fun countRecompositions(): Int {
+    val counter = remember { intArrayOf(0) }
+    counter[0]++
+    return counter[0]
+}
+
+private val GAP = 16.dp

--- a/app/hilt/src/main/kotlin/com/ktomek/yamv/profile/logic/ProfileIntentions.kt
+++ b/app/hilt/src/main/kotlin/com/ktomek/yamv/profile/logic/ProfileIntentions.kt
@@ -1,0 +1,7 @@
+package com.ktomek.yamv.profile.logic
+
+data class UpdateNameIntention(val value: String)
+
+data class UpdateEmailIntention(val value: String)
+
+data object SaveProfileIntention

--- a/app/hilt/src/main/kotlin/com/ktomek/yamv/profile/logic/feature/ProfileEditFeatures.kt
+++ b/app/hilt/src/main/kotlin/com/ktomek/yamv/profile/logic/feature/ProfileEditFeatures.kt
@@ -1,0 +1,19 @@
+package com.ktomek.yamv.profile.logic.feature
+
+import com.ktomek.yamv.annotations.AutoFeature
+import com.ktomek.yamv.feature.functionTypedFeature
+import com.ktomek.yamv.profile.logic.UpdateEmailIntention
+import com.ktomek.yamv.profile.logic.UpdateNameIntention
+import com.ktomek.yamv.profile.logic.outcome.SetEmailOutcome
+import com.ktomek.yamv.profile.logic.outcome.SetNameOutcome
+import com.ktomek.yamv.profile.logic.state.ProfileState
+
+@AutoFeature
+val updateNameFeature = functionTypedFeature<ProfileState, UpdateNameIntention> {
+    SetNameOutcome(it.value)
+}
+
+@AutoFeature
+val updateEmailFeature = functionTypedFeature<ProfileState, UpdateEmailIntention> {
+    SetEmailOutcome(it.value)
+}

--- a/app/hilt/src/main/kotlin/com/ktomek/yamv/profile/logic/feature/SaveProfileFeature.kt
+++ b/app/hilt/src/main/kotlin/com/ktomek/yamv/profile/logic/feature/SaveProfileFeature.kt
@@ -1,0 +1,49 @@
+package com.ktomek.yamv.profile.logic.feature
+
+import com.ktomek.yamv.annotations.AutoFeature
+import com.ktomek.yamv.feature.Feature.FlowFeature
+import com.ktomek.yamv.profile.logic.SaveProfileIntention
+import com.ktomek.yamv.profile.logic.outcome.ProfileOutcome
+import com.ktomek.yamv.profile.logic.outcome.SavingOutcome
+import com.ktomek.yamv.profile.logic.outcome.ValidationTickOutcome
+import com.ktomek.yamv.profile.logic.state.ProfileState
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
+import javax.inject.Inject
+
+/**
+ * Simulates a save with retry/validation bookkeeping.
+ *
+ * A single [SaveProfileIntention] produces many state emissions — `isSaving` flips
+ * on, several [ValidationTickOutcome]s churn internal bookkeeping, then `isSaving`
+ * flips off. Only the two `isSaving` transitions change the UI projection, so a
+ * screen collecting `uiState()` recomposes twice while a screen collecting the
+ * full state recomposes on every tick.
+ */
+@AutoFeature
+class SaveProfileFeature @Inject constructor() : FlowFeature<ProfileState> {
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    override fun invoke(intentions: Flow<Any>): Flow<ProfileOutcome> =
+        intentions
+            .filterIsInstance<SaveProfileIntention>()
+            .flatMapLatest { saveFlow() }
+
+    private fun saveFlow(): Flow<ProfileOutcome> = flow {
+        emit(SavingOutcome(true))
+        repeat(VALIDATION_PASSES) { pass ->
+            delay(VALIDATION_DELAY_MS)
+            emit(ValidationTickOutcome(token = pass.toLong()))
+        }
+        emit(SavingOutcome(false))
+    }
+
+    private companion object {
+        const val VALIDATION_PASSES = 5
+        const val VALIDATION_DELAY_MS = 150L
+    }
+}

--- a/app/hilt/src/main/kotlin/com/ktomek/yamv/profile/logic/outcome/ProfileOutcomes.kt
+++ b/app/hilt/src/main/kotlin/com/ktomek/yamv/profile/logic/outcome/ProfileOutcomes.kt
@@ -1,0 +1,36 @@
+package com.ktomek.yamv.profile.logic.outcome
+
+import com.ktomek.yamv.core.Outcome
+import com.ktomek.yamv.core.StateOutcome
+import com.ktomek.yamv.profile.logic.state.ProfileState
+
+typealias ProfileOutcome = Outcome<ProfileState>
+typealias ProfileReducer = StateOutcome<ProfileState>
+
+data class SetNameOutcome(val value: String) : ProfileReducer {
+    override fun reduce(prevState: ProfileState): ProfileState =
+        prevState.copy(name = value)
+}
+
+data class SetEmailOutcome(val value: String) : ProfileReducer {
+    override fun reduce(prevState: ProfileState): ProfileState =
+        prevState.copy(email = value)
+}
+
+data class SavingOutcome(val isSaving: Boolean) : ProfileReducer {
+    override fun reduce(prevState: ProfileState): ProfileState =
+        prevState.copy(isSaving = isSaving)
+}
+
+/**
+ * Internal-only churn: bumps bookkeeping fields the UI never observes. Emitting
+ * this re-emits state, but `ProfileState.toUiState()` is unchanged — so a
+ * projected collector does not recompose.
+ */
+data class ValidationTickOutcome(val token: Long) : ProfileReducer {
+    override fun reduce(prevState: ProfileState): ProfileState =
+        prevState.copy(
+            saveAttempts = prevState.saveAttempts + 1,
+            lastValidationToken = token,
+        )
+}

--- a/app/hilt/src/main/kotlin/com/ktomek/yamv/profile/logic/state/ProfileState.kt
+++ b/app/hilt/src/main/kotlin/com/ktomek/yamv/profile/logic/state/ProfileState.kt
@@ -1,0 +1,33 @@
+package com.ktomek.yamv.profile.logic.state
+
+import com.ktomek.yamv.annotations.AutoState
+import com.ktomek.yamv.core.State
+import com.ktomek.yamv.core.UiMappable
+import com.ktomek.yamv.profile.logic.uistate.ProfileUiState
+
+/**
+ * Full business-logic state for the profile screen.
+ *
+ * Note the split between UI-relevant fields ([name], [email], [isSaving]) and
+ * internal bookkeeping ([saveAttempts], [lastValidationToken]) that the UI must
+ * never observe. The bookkeeping fields churn during a save, re-emitting state,
+ * but they are intentionally excluded from [ProfileUiState] — so a screen that
+ * collects [toUiState] does not recompose when only bookkeeping changes.
+ */
+@AutoState
+data class ProfileState(
+    val name: String = "",
+    val email: String = "",
+    val isSaving: Boolean = false,
+    // Internal bookkeeping — deliberately NOT part of the UI projection.
+    val saveAttempts: Int = 0,
+    val lastValidationToken: Long = 0L,
+) : State, UiMappable<ProfileUiState> {
+
+    override fun toUiState(): ProfileUiState = ProfileUiState(
+        name = name,
+        email = email,
+        isSaving = isSaving,
+        canSave = name.isNotBlank() && email.contains("@") && !isSaving,
+    )
+}

--- a/app/hilt/src/main/kotlin/com/ktomek/yamv/profile/logic/uistate/ProfileUiState.kt
+++ b/app/hilt/src/main/kotlin/com/ktomek/yamv/profile/logic/uistate/ProfileUiState.kt
@@ -1,0 +1,15 @@
+package com.ktomek.yamv.profile.logic.uistate
+
+/**
+ * UI-facing projection of `ProfileState`.
+ *
+ * Holds only what the screen renders, plus the derived [canSave] flag. Internal
+ * bookkeeping from the full state is excluded, so collectors only recompose when
+ * one of these values actually changes.
+ */
+data class ProfileUiState(
+    val name: String,
+    val email: String,
+    val isSaving: Boolean,
+    val canSave: Boolean,
+)

--- a/site-docs/architecture.md
+++ b/site-docs/architecture.md
@@ -18,6 +18,10 @@ flowchart LR
 
 **The cycle:** UI dispatches an intention → Store routes it to matching features → features emit outcomes → outcomes update state → UI observes new state.
 
+> The UI observes the full `StateFlow<S>` by default. To project state down to a
+> UI-only type and skip recompositions on internal changes, see
+> [UI State Projection](features.md#ui-state-projection).
+
 Outcomes come in three kinds:
 
 - **`StateOutcome`** — pure `(S) → S` reducer, applied via `scan()`

--- a/site-docs/features.md
+++ b/site-docs/features.md
@@ -172,3 +172,83 @@ class LoginFeature(
             .catch { e -> emit(LoginErrorOutcome(e.message)) }
 }
 ```
+
+## UI State Projection
+
+`store.state` exposes the full business-logic `State`. In real apps that state often
+carries internal bookkeeping the UI never renders — retry counters, validation tokens,
+pagination cursors. Because Compose recomposes whenever the collected value changes, a
+screen observing the full state recomposes on every internal change, even when nothing
+visible moved.
+
+YAMV offers an **opt-in** projection from `State` to a UI-only type. `store.state`
+remains the default path; reach for projection only when internal churn causes wasted
+recompositions.
+
+### `UiMappable` + `uiState()`
+
+Have the state declare its UI projection by implementing `UiMappable<UiS>`:
+
+```kotlin
+data class ProfileState(
+    val name: String = "",
+    val email: String = "",
+    val isSaving: Boolean = false,
+    // internal — never rendered:
+    val saveAttempts: Int = 0,
+    val lastValidationToken: Long = 0L,
+) : State, UiMappable<ProfileUiState> {
+    override fun toUiState() = ProfileUiState(
+        name = name,
+        email = email,
+        isSaving = isSaving,
+        canSave = name.isNotBlank() && email.contains("@") && !isSaving, // derived
+    )
+}
+
+data class ProfileUiState(
+    val name: String,
+    val email: String,
+    val isSaving: Boolean,
+    val canSave: Boolean,
+)
+```
+
+In Compose, collect the projection with the type-safe `uiState()` shorthand. It applies
+`distinctUntilChanged`, so the screen only recomposes when a projected value actually
+changes — bumping `saveAttempts` re-emits `State` but does **not** recompose the UI:
+
+```kotlin
+@Composable
+fun ProfileScreen(store: ProfileStateStore = hiltMviStore()) {
+    val scope = rememberCoroutineScope()
+    val ui by remember(store, scope) {
+        store.uiState<ProfileState, ProfileUiState>(scope)
+    }.collectAsState()
+
+    // ui.name, ui.email, ui.canSave, ui.isSaving
+}
+```
+
+### `mapToUiState()` — any mapper
+
+When the state does not implement `UiMappable` (or you want a screen-specific
+projection), map the `StateFlow` directly:
+
+```kotlin
+val ui by remember(store, scope) {
+    store.state.mapToUiState(scope) { state ->
+        ProfileUiState(
+            name = state.name,
+            email = state.email,
+            isSaving = state.isSaving,
+            canSave = state.name.isNotBlank() && state.email.contains("@"),
+        )
+    }
+}.collectAsState()
+```
+
+Both helpers live in `:yamv` and work on every Kotlin Multiplatform target, so the same
+projection applies under Hilt or Koin. A runnable end-to-end demo lives in the Hilt
+sample app (`app/hilt`, the **Profile** screen), which shows a projected collector and a
+raw-state collector side by side so the difference in recompositions is visible.

--- a/yamv-core/src/main/kotlin/com/ktomek/yamv/core/UiMappable.kt
+++ b/yamv-core/src/main/kotlin/com/ktomek/yamv/core/UiMappable.kt
@@ -1,0 +1,14 @@
+package com.ktomek.yamv.core
+
+/**
+ * Opt-in interface for State classes that declare a UI projection.
+ *
+ * Implementing this allows using [MviStore.uiState()] for type-safe
+ * State → UiState mapping with [distinctUntilChanged] to minimize
+ * Compose recompositions.
+ *
+ * @param UiS the UI state type — typically a subset of the full State
+ */
+interface UiMappable<UiS : Any> {
+    fun toUiState(): UiS
+}

--- a/yamv/src/main/kotlin/com/ktomek/yamv/state/UiStateMapping.kt
+++ b/yamv/src/main/kotlin/com/ktomek/yamv/state/UiStateMapping.kt
@@ -1,0 +1,42 @@
+package com.ktomek.yamv.state
+
+import com.ktomek.yamv.core.State
+import com.ktomek.yamv.core.UiMappable
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+
+private const val DEFAULT_STOP_TIMEOUT_MS = 5_000L
+
+/**
+ * Maps a [StateFlow] of [S] to a [StateFlow] of [UiS] with [distinctUntilChanged],
+ * so downstream collectors (e.g. Compose) only recompose when the UI-relevant
+ * subset of state actually changes.
+ *
+ * @param scope the [CoroutineScope] used for sharing (e.g. `viewModelScope` or `rememberCoroutineScope()`)
+ * @param started sharing strategy, defaults to [SharingStarted.WhileSubscribed] with 5s stop timeout
+ * @param mapper transforms the full state into the UI state subset
+ */
+fun <S : State, UiS : Any> StateFlow<S>.mapToUiState(
+    scope: CoroutineScope,
+    started: SharingStarted = SharingStarted.WhileSubscribed(DEFAULT_STOP_TIMEOUT_MS),
+    mapper: (S) -> UiS,
+): StateFlow<UiS> =
+    map(mapper)
+        .distinctUntilChanged()
+        .stateIn(scope, started, mapper(value))
+
+/**
+ * Type-safe shorthand for [mapToUiState] when the State implements [UiMappable].
+ *
+ * @param scope the [CoroutineScope] used for sharing
+ * @param started sharing strategy, defaults to [SharingStarted.WhileSubscribed] with 5s stop timeout
+ */
+fun <S, UiS : Any> MviStore<S, *>.uiState(
+    scope: CoroutineScope,
+    started: SharingStarted = SharingStarted.WhileSubscribed(DEFAULT_STOP_TIMEOUT_MS),
+): StateFlow<UiS> where S : State, S : UiMappable<UiS> =
+    state.mapToUiState(scope, started) { it.toUiState() }

--- a/yamv/src/test/kotlin/com/ktomek/yamv/state/UiStateMappingTest.kt
+++ b/yamv/src/test/kotlin/com/ktomek/yamv/state/UiStateMappingTest.kt
@@ -1,0 +1,109 @@
+package com.ktomek.yamv.state
+
+import com.google.common.truth.Truth.assertThat
+import com.ktomek.yamv.core.State
+import com.ktomek.yamv.core.StateOutcome
+import com.ktomek.yamv.core.UiMappable
+import com.ktomek.yamv.feature.FunctionTypedFeature
+import com.ktomek.yamv.feature.wrap
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+private data class FullState(
+    val count: Int = 0,
+    val internalRetryCount: Int = 0,
+    val paginationCursor: String? = null,
+) : State, UiMappable<TestUiState> {
+    override fun toUiState() = TestUiState(displayCount = count.toString())
+}
+
+private data class TestUiState(val displayCount: String)
+
+private sealed class TestIntention {
+    data object Increment : TestIntention()
+}
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class UiStateMappingTest {
+
+    @Test
+    fun `mapToUiState produces correct initial value`() = runTest(UnconfinedTestDispatcher()) {
+        val state = MutableStateFlow(FullState(count = 42))
+        val uiState = state.mapToUiState(backgroundScope, SharingStarted.Eagerly) { it.toUiState() }
+
+        assertThat(uiState.value.displayCount).isEqualTo("42")
+    }
+
+    @Test
+    fun `mapToUiState emits only when UiState changes`() = runTest(UnconfinedTestDispatcher()) {
+        val state = MutableStateFlow(FullState())
+        val emissions = mutableListOf<TestUiState>()
+
+        val uiState = state.mapToUiState(backgroundScope, SharingStarted.Eagerly) { it.toUiState() }
+        val job = backgroundScope.launch { uiState.collect { emissions.add(it) } }
+
+        // Change internal field only — UiState should NOT change
+        state.value = state.value.copy(internalRetryCount = 5)
+        state.value = state.value.copy(paginationCursor = "abc")
+
+        // Change count — UiState SHOULD change
+        state.value = state.value.copy(count = 1)
+
+        // Initial "0" + updated "1" = 2 distinct emissions
+        assertThat(emissions.map { it.displayCount }).containsExactly("0", "1").inOrder()
+
+        job.cancel()
+    }
+
+    @Test
+    fun `uiState extension works with UiMappable interface`() = runTest {
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val feature = FunctionTypedFeature<FullState, TestIntention.Increment> {
+            StateOutcome { s -> s.copy(count = s.count + 1) }
+        }
+        val config = object : CoroutineDispatcherConfig {
+            override fun provideIntentionDispatcher(intention: Any?) = testDispatcher
+            override fun provideReducerDispatcher() = testDispatcher
+            override fun provideFeatureDispatcher(feature: Any) = testDispatcher
+        }
+
+        val runtime = MviRuntime(
+            features = setOf(feature.wrap()),
+            defaultState = FullState(),
+            dispatcherConfig = config,
+        )
+
+        val uiState = runtime.uiState<FullState, TestUiState>(backgroundScope, SharingStarted.Eagerly)
+        advanceUntilIdle()
+
+        assertThat(uiState.value.displayCount).isEqualTo("0")
+
+        runtime.dispatch(TestIntention.Increment)
+        advanceUntilIdle()
+
+        assertThat(uiState.value.displayCount).isEqualTo("1")
+        runtime.clear()
+    }
+
+    @Test
+    fun `mapToUiState with custom mapper`() = runTest(UnconfinedTestDispatcher()) {
+        val state = MutableStateFlow(FullState(count = 7))
+
+        val uiState = state.mapToUiState(backgroundScope, SharingStarted.Eagerly) { s ->
+            TestUiState(displayCount = "Count: ${s.count}")
+        }
+
+        assertThat(uiState.value.displayCount).isEqualTo("Count: 7")
+
+        state.value = state.value.copy(count = 99)
+
+        assertThat(uiState.value.displayCount).isEqualTo("Count: 99")
+    }
+}


### PR DESCRIPTION
## Summary

Add opt-in State → UiState mapping to minimize Compose recompositions. Full business-logic state often contains internal fields (loading flags, pagination cursors, retry counts) that the UI shouldn't observe.

## New types

- **`UiMappable<UiS>`** in `:yamv-core` — interface for State classes to declare their UI projection
- **`mapToUiState()`** in `:yamv` — extension on `StateFlow<S>` with any mapper + `distinctUntilChanged`
- **`uiState()`** in `:yamv` — type-safe shorthand when State implements `UiMappable`

## Usage

```kotlin
// State declares its UiState mapping
data class CounterState(
    val count: Int = 0,
    val retryCount: Int = 0, // internal
) : State, UiMappable<CounterUiState> {
    override fun toUiState() = CounterUiState(displayCount = count.toString())
}

data class CounterUiState(val displayCount: String)

// In Compose — only recomposes when displayCount changes
val ui by store.state.mapToUiState(scope) { it.toUiState() }.collectAsState()

// Or type-safe shorthand
val ui by store.uiState<CounterState, CounterUiState>(scope).collectAsState()
```

Both approaches are opt-in. `store.state` remains the default path.

## Test plan
- [x] `mapToUiState` produces correct initial value
- [x] `mapToUiState` emits only when UiState actually changes
- [x] `mapToUiState` with custom mapper
- [x] `uiState()` works with `UiMappable` interface via `MviRuntime`
- [x] `./gradlew :yamv:jvmTest` all pass
- [x] `./gradlew detektAll` passes

**Note:** This PR is based on #38 (module rename). Merge #38 first.

Closes #39