### PR TITLE
feat: typed koinMviStore with cross-navigation sharing (#41)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,13 @@ Annotate feature classes/properties with `@AutoFeature` to generate `{StateName}
 
 `FeatureRouter` uses `CompletableDeferred` to ensure all features are subscribed before the first intention is dispatched. `MviRuntime` manages three independent coroutine collectors (reducers, effects, intention re-dispatch) and is cancelled via `clear()`.
 
+### Koin integration
+
+- `koinMviStore<S, I>()` returns `MviStore<S, I>` (narrow interface, not the internal `KoinMviRetainedStore`). `I` is the intention type — use a sealed class for type safety, or `Any` for untyped dispatch.
+- `mviStore<S, I>(...)` DSL registers the store in a Koin module with matching types.
+- `MviStoreOwner` is a typealias for `ViewModelStoreOwner`. `LocalMviStoreOwner` mirrors `LocalViewModelStoreOwner` with the aliased type.
+- For app-lifetime state across navigation, wrap the `NavHost` in `ProvideAppMviStoreOwner { ... }` and resolve stores via `koinMviAppStore<S, I>()`.
+
 ## Testing
 
 Tests use JUnit 5, MockK, Turbine (Flow testing), and Truth assertions. See `yamv/src/test/` for examples.

--- a/app/koin/src/commonMain/kotlin/com/ktomek/yamv/koin/counter/CounterFeaturesModule.kt
+++ b/app/koin/src/commonMain/kotlin/com/ktomek/yamv/koin/counter/CounterFeaturesModule.kt
@@ -13,7 +13,7 @@ val counterModule = module {
     factory { DecreaseFeature() }
     factory { AutoIncreaseFeature(get()) }
 
-    mviStore(defaultState = CounterState()) {
+    mviStore<CounterState, Any>(defaultState = CounterState()) {
         add(get<AutoDecreaseFeature>())
         add(get<AutoIncreaseFeature>())
         add(get<DecreaseFeature>())

--- a/app/koin/src/commonMain/kotlin/com/ktomek/yamv/koin/counter/CounterScreen.kt
+++ b/app/koin/src/commonMain/kotlin/com/ktomek/yamv/koin/counter/CounterScreen.kt
@@ -3,9 +3,9 @@ package com.ktomek.yamv.koin.counter
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import com.ktomek.yamv.koin.KoinMviRetainedStore
 import com.ktomek.yamv.koin.counter.logic.state.CounterState
 import com.ktomek.yamv.koin.koinMviStore
+import com.ktomek.yamv.state.MviStore
 import com.ktomek.yamv.ui.counter.logic.AutoDecreaseCounterIntention
 import com.ktomek.yamv.ui.counter.logic.AutoIncreaseCounterIntention
 import com.ktomek.yamv.ui.counter.logic.DecreaseCounterIntention
@@ -16,7 +16,7 @@ import com.ktomek.yamv.ui.counter.view.CounterContent
 
 @Composable
 fun CounterScreen(
-    store: KoinMviRetainedStore<CounterState> = koinMviStore()
+    store: MviStore<CounterState, Any> = koinMviStore()
 ) {
     val state by store.state.collectAsState()
     CounterContent(

--- a/site-docs/multiplatform.md
+++ b/site-docs/multiplatform.md
@@ -36,12 +36,14 @@ Using the `mviStore {}` DSL — typed features are wrapped automatically via `ad
 val counterModule = module {
     factoryOf(::IncrementFeature)
     factoryOf(::DecrementFeature)
-    mviStore(defaultState = CounterState()) {
+    mviStore<CounterState, CounterIntention>(defaultState = CounterState()) {
         add(get<IncrementFeature>())   // .wrap() applied automatically
         add(get<DecrementFeature>())
     }
 }
 ```
+
+`mviStore<S, I>` takes two type params: the state type and the intention type. Use `Any` for `I` if you prefer untyped dispatch.
 
 Or manual wiring with explicit `.wrap()`:
 
@@ -64,13 +66,39 @@ val counterModule = module {
 ```kotlin
 // commonMain
 @Composable
-fun CounterScreen(store: KoinMviRetainedStore<CounterState> = koinMviStore()) {
+fun CounterScreen(
+    store: MviStore<CounterState, CounterIntention> = koinMviStore(),
+) {
     val state by store.state.collectAsStateWithLifecycle()
     // ...
 }
 ```
 
-### 4. iOS entry point
+### 4. Sharing state across navigation
+
+By default `koinMviStore()` resolves through `LocalViewModelStoreOwner.current`, which Compose Multiplatform's `NavHost` overrides per back-stack entry — so every `composable<Route> { ... }` gets its own store. For app-lifetime state (auth, session, preferences) that needs to survive navigation:
+
+```kotlin
+@Composable
+fun App() {
+    ProvideAppMviStoreOwner {
+        NavHost(...) {
+            composable<AuthGraph.SignIn> { AuthScreen() }
+            composable<HomeGraph.Root> { HomeScreen() }
+        }
+    }
+}
+
+@Composable
+fun AuthScreen(
+    // Same instance everywhere the app can reach it
+    store: MviStore<AuthState, AuthIntention> = koinMviAppStore(),
+) { ... }
+```
+
+Screens that don't call `koinMviAppStore()` continue to use the per-destination scope. You can also pass an explicit owner: `koinMviStore(myOwner)`.
+
+### 5. iOS entry point
 
 ```kotlin
 // iosMain

--- a/yamv-koin/src/commonMain/kotlin/com/ktomek/yamv/koin/AppMviStoreOwner.kt
+++ b/yamv-koin/src/commonMain/kotlin/com/ktomek/yamv/koin/AppMviStoreOwner.kt
@@ -1,0 +1,51 @@
+package com.ktomek.yamv.koin
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.staticCompositionLocalOf
+import com.ktomek.yamv.core.State
+import com.ktomek.yamv.state.MviStore
+
+/**
+ * Compose local carrying the app-root [MviStoreOwner], set by [ProvideAppMviStoreOwner].
+ *
+ * Use together with [koinMviAppStore] to obtain stores scoped to the entire app lifetime
+ * (surviving navigation changes), not to the current back-stack entry.
+ */
+val LocalAppMviStoreOwner = staticCompositionLocalOf<MviStoreOwner> {
+    error("ProvideAppMviStoreOwner { ... } not set. Wrap your NavHost (or root composable) with it.")
+}
+
+/**
+ * Captures the current [MviStoreOwner] as the app-root owner and exposes it via
+ * [LocalAppMviStoreOwner] to descendants.
+ *
+ * Place this **above** your `NavHost`, because `NavHost` overrides
+ * `LocalViewModelStoreOwner` per back-stack entry.
+ *
+ * ```kotlin
+ * @Composable
+ * fun App() {
+ *     ProvideAppMviStoreOwner {
+ *         NavHost(...) { ... }
+ *     }
+ * }
+ * ```
+ */
+@Composable
+fun ProvideAppMviStoreOwner(content: @Composable () -> Unit) {
+    val rootOwner = checkNotNull(LocalMviStoreOwner.current) {
+        "No MviStoreOwner in composition"
+    }
+    CompositionLocalProvider(LocalAppMviStoreOwner provides rootOwner, content = content)
+}
+
+/**
+ * Returns an [MviStore] scoped to the app-root owner captured by [ProvideAppMviStoreOwner].
+ *
+ * All calls from anywhere in the composition resolve to the same instance, regardless of
+ * the current navigation entry.
+ */
+@Composable
+inline fun <reified S : State, reified I : Any> koinMviAppStore(): MviStore<S, I> =
+    koinMviStore(LocalAppMviStoreOwner.current)

--- a/yamv-koin/src/commonMain/kotlin/com/ktomek/yamv/koin/KoinMviRetainedStore.kt
+++ b/yamv-koin/src/commonMain/kotlin/com/ktomek/yamv/koin/KoinMviRetainedStore.kt
@@ -20,19 +20,26 @@ import org.koin.core.qualifier.named
  *
  * Replaces per-state generated classes (e.g. `CounterStateStore`). Register it via [mviStore]
  * and retrieve it via [koinMviStore] — both derive the Koin qualifier from [S] automatically.
+ *
+ * @param S state type
+ * @param I intention type — narrows [MviStore.dispatch] at compile time. Use [Any] for untyped.
  */
 @OpenForTesting
-class KoinMviRetainedStore<S : State>(
+class KoinMviRetainedStore<S : State, I : Any>(
     features: Set<Feature<S>>,
     defaultState: S,
     dispatcherConfig: CoroutineDispatcherConfig = DefaultCoroutineDispatcherConfig(),
-) : MviRetainedStore<S, Any>() {
+) : MviRetainedStore<S, I>() {
     override val dispatcherConfig: CoroutineDispatcherConfig = dispatcherConfig
-    override val store: MviStore<S, Any> = MviRuntime(
-        features = features,
-        defaultState = defaultState,
-        dispatcherConfig = dispatcherConfig,
-    )
+    override val store: MviStore<S, I> =
+        @Suppress("UNCHECKED_CAST")
+        (
+            MviRuntime(
+                features = features,
+                defaultState = defaultState,
+                dispatcherConfig = dispatcherConfig,
+            ) as MviStore<S, I>
+            )
 }
 
 /**
@@ -44,7 +51,8 @@ class KoinMviRetainedStore<S : State>(
 inline fun <reified S : State> stateQualifier(): Qualifier = named(S::class.simpleName!!)
 
 /**
- * Registers a [KoinMviRetainedStore] for state type [S] as a Koin ViewModel, qualified by [stateQualifier].
+ * Registers a [KoinMviRetainedStore] for state type [S] and intention type [I] as a Koin
+ * ViewModel, qualified by [stateQualifier].
  *
  * Call this inside a `module { }` block. The [features] lambda receives a [FeatureRegistrar]
  * so `add(feature)` and `get<T>()` are available without calling `.wrap()` manually.
@@ -55,14 +63,14 @@ inline fun <reified S : State> stateQualifier(): Qualifier = named(S::class.simp
  *     factory { AutoDecreaseFeature() }
  *     factory { DecreaseFeature() }
  *
- *     mviStore(defaultState = CounterState()) {
- *         add(get<AutoDecreaseFeature>())   // FlowFeature — passed through
- *         add(get<DecreaseFeature>())       // FunctionTypedFeature — wrapped automatically
+ *     mviStore<CounterState, CounterIntention>(defaultState = CounterState()) {
+ *         add(get<AutoDecreaseFeature>())
+ *         add(get<DecreaseFeature>())
  *     }
  * }
  * ```
  */
-inline fun <reified S : State> Module.mviStore(
+inline fun <reified S : State, reified I : Any> Module.mviStore(
     defaultState: S,
     dispatcherConfig: CoroutineDispatcherConfig = DefaultCoroutineDispatcherConfig(),
     crossinline features: FeatureRegistrar<S>.() -> Unit,
@@ -70,7 +78,7 @@ inline fun <reified S : State> Module.mviStore(
     viewModel(stateQualifier<S>()) {
         val registrar = FeatureRegistrar<S>(this)
         registrar.features()
-        KoinMviRetainedStore(
+        KoinMviRetainedStore<S, I>(
             features = registrar.build(),
             defaultState = defaultState,
             dispatcherConfig = dispatcherConfig,
@@ -79,16 +87,28 @@ inline fun <reified S : State> Module.mviStore(
 }
 
 /**
- * Returns the [KoinMviRetainedStore] for state type [S] scoped to the current navigation back-stack entry.
+ * Returns the [MviStore] for state type [S] and intention type [I], scoped to [storeOwner].
  *
- * The qualifier is derived from [S] automatically — no string literals needed at call sites.
+ * By default [storeOwner] is `LocalViewModelStoreOwner.current`, which in Compose Multiplatform's
+ * Navigation is overridden per `NavBackStackEntry` — so each navigation destination gets its own
+ * store instance. For app-lifetime state (auth, session, preferences) pass an app-level owner,
+ * or use [koinMviAppStore] together with [ProvideAppMviStoreOwner].
  *
  * Usage:
  * ```kotlin
  * @Composable
- * fun CounterScreen(store: KoinMviRetainedStore<CounterState> = koinMviStore()) { ... }
+ * fun CounterScreen(
+ *     store: MviStore<CounterState, CounterIntention> = koinMviStore(),
+ * ) { ... }
  * ```
  */
 @Composable
-inline fun <reified S : State> koinMviStore(): KoinMviRetainedStore<S> =
-    koinViewModel(stateQualifier<S>())
+inline fun <reified S : State, reified I : Any> koinMviStore(
+    storeOwner: MviStoreOwner = checkNotNull(LocalMviStoreOwner.current) {
+        "No MviStoreOwner in composition (LocalMviStoreOwner.current was null)"
+    },
+): MviStore<S, I> =
+    koinViewModel<KoinMviRetainedStore<S, I>>(
+        qualifier = stateQualifier<S>(),
+        viewModelStoreOwner = storeOwner,
+    )

--- a/yamv-koin/src/commonMain/kotlin/com/ktomek/yamv/koin/MviStoreOwner.kt
+++ b/yamv-koin/src/commonMain/kotlin/com/ktomek/yamv/koin/MviStoreOwner.kt
@@ -1,0 +1,28 @@
+package com.ktomek.yamv.koin
+
+import androidx.compose.runtime.Composable
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+
+/**
+ * The lifecycle-scoped owner that retains an MVI store instance.
+ *
+ * Typealiased to [ViewModelStoreOwner] — the underlying mechanism is the multiplatform
+ * ViewModel store, but public APIs prefer this name so the MVI surface stays free of
+ * ViewModel terminology.
+ */
+typealias MviStoreOwner = ViewModelStoreOwner
+
+/**
+ * Access the current [MviStoreOwner] from composition.
+ *
+ * Delegates to [LocalViewModelStoreOwner]. In Compose Multiplatform's Navigation this is
+ * overridden per `NavBackStackEntry`, which is why app-lifetime state requires capturing
+ * the root owner explicitly — see [ProvideAppMviStoreOwner].
+ */
+@Suppress("ClassName", "ClassNaming")
+object LocalMviStoreOwner {
+    val current: MviStoreOwner?
+        @Composable
+        get() = LocalViewModelStoreOwner.current
+}

--- a/yamv-koin/src/test/kotlin/com/ktomek/yamv/koin/KoinMviRetainedStoreDispatcherConfigTest.kt
+++ b/yamv-koin/src/test/kotlin/com/ktomek/yamv/koin/KoinMviRetainedStoreDispatcherConfigTest.kt
@@ -55,7 +55,7 @@ private class InspectableMviRetainedStore<S : State>(
     features: Set<Feature<S>>,
     defaultState: S,
     config: CoroutineDispatcherConfig,
-) : KoinMviRetainedStore<S>(
+) : KoinMviRetainedStore<S, Any>(
     features = features,
     defaultState = defaultState,
     dispatcherConfig = config,
@@ -157,12 +157,12 @@ class KoinMviRetainedStoreDispatcherConfigTest {
         // Arrange
         val customConfig = TrackingCoroutineDispatcherConfig()
         val koinModule = module {
-            mviStore(defaultState = TestState(), dispatcherConfig = customConfig) {}
+            mviStore<TestState, Any>(defaultState = TestState(), dispatcherConfig = customConfig) {}
         }
 
         // Act
         val koinApp = KoinApplication.init().modules(koinModule)
-        koinApp.koin.get<KoinMviRetainedStore<TestState>>(stateQualifier<TestState>())
+        koinApp.koin.get<KoinMviRetainedStore<TestState, Any>>(stateQualifier<TestState>())
 
         // Assert — MviRuntime calls provideReducerDispatcher on init using the custom config
         assertTrue(

--- a/yamv-koin/src/test/kotlin/com/ktomek/yamv/koin/KoinMviStoreScopeTest.kt
+++ b/yamv-koin/src/test/kotlin/com/ktomek/yamv/koin/KoinMviStoreScopeTest.kt
@@ -1,0 +1,153 @@
+package com.ktomek.yamv.koin
+
+import com.ktomek.yamv.core.State
+import com.ktomek.yamv.core.StateOutcome
+import com.ktomek.yamv.feature.FunctionTypedFeature
+import com.ktomek.yamv.feature.wrap
+import com.ktomek.yamv.state.CoroutineDispatcherConfig
+import com.ktomek.yamv.state.DefaultCoroutineDispatcherConfig
+import com.ktomek.yamv.state.MviStore
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.koin.core.KoinApplication
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private data class TypedTestState(val count: Int = 0) : State
+
+private sealed class TypedTestIntention {
+    data object Increment : TypedTestIntention()
+}
+
+class KoinMviStoreScopeTest {
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @BeforeEach
+    fun setUp() {
+        Dispatchers.setMain(StandardTestDispatcher())
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @AfterEach
+    fun tearDown() {
+        Dispatchers.resetMain()
+        stopKoin()
+    }
+
+    @Test
+    fun `GIVEN typed KoinMviRetainedStore WHEN intention dispatched THEN state is reduced`() = runTest {
+        // Arrange
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val feature = FunctionTypedFeature<TypedTestState, TypedTestIntention.Increment> {
+            StateOutcome { s -> s.copy(count = s.count + 1) }
+        }
+        val store = KoinMviRetainedStore<TypedTestState, TypedTestIntention>(
+            features = setOf(feature.wrap()),
+            defaultState = TypedTestState(),
+            dispatcherConfig = testDispatcherConfig(testDispatcher),
+        )
+
+        // Allow feature coroutines to subscribe before dispatching
+        advanceUntilIdle()
+
+        // Act — typed dispatch compiles and works
+        store.dispatch(TypedTestIntention.Increment)
+        advanceUntilIdle()
+
+        // Assert
+        assertEquals(1, store.state.value.count)
+        store.clear()
+    }
+
+    private fun testDispatcherConfig(dispatcher: CoroutineDispatcher) =
+        object : CoroutineDispatcherConfig {
+            override fun provideIntentionDispatcher(intention: Any?) = dispatcher
+            override fun provideReducerDispatcher() = dispatcher
+            override fun provideFeatureDispatcher(feature: Any) = dispatcher
+        }
+
+    @Test
+    fun `GIVEN typed mviStore DSL WHEN resolved THEN returns typed store`() {
+        // Arrange
+        val koinModule = module {
+            mviStore<TypedTestState, TypedTestIntention>(
+                defaultState = TypedTestState(),
+                dispatcherConfig = DefaultCoroutineDispatcherConfig(),
+            ) {}
+        }
+
+        // Act
+        val koinApp = KoinApplication.init().modules(koinModule)
+        val store = koinApp.koin.get<KoinMviRetainedStore<TypedTestState, TypedTestIntention>>(
+            stateQualifier<TypedTestState>(),
+        )
+
+        // Assert — the store implements MviStore<TypedTestState, TypedTestIntention>
+        val asInterface: MviStore<TypedTestState, TypedTestIntention> = store
+        assertEquals(0, asInterface.state.value.count)
+    }
+
+    @Test
+    fun `GIVEN untyped mviStore DSL WHEN resolved THEN returns untyped store accepting Any`() {
+        // Arrange — Any-typed still works (explicit intention type Any)
+        val koinModule = module {
+            mviStore<TypedTestState, Any>(
+                defaultState = TypedTestState(),
+                dispatcherConfig = DefaultCoroutineDispatcherConfig(),
+            ) {}
+        }
+
+        // Act
+        val koinApp = KoinApplication.init().modules(koinModule)
+        val store = koinApp.koin.get<KoinMviRetainedStore<TypedTestState, Any>>(
+            stateQualifier<TypedTestState>(),
+        )
+
+        // Assert — Any-typed dispatch accepts anything
+        assertTrue(store.state.value.count == 0)
+    }
+
+    @Test
+    fun `GIVEN two separately instantiated stores WHEN same feature WHEN independent THEN state is independent`() = runTest {
+        // Arrange — sanity check that manually constructed stores are independent
+        val testDispatcher = StandardTestDispatcher(testScheduler)
+        val feature = FunctionTypedFeature<TypedTestState, TypedTestIntention.Increment> {
+            StateOutcome { s -> s.copy(count = s.count + 1) }
+        }
+        val storeA = KoinMviRetainedStore<TypedTestState, TypedTestIntention>(
+            features = setOf(feature.wrap()),
+            defaultState = TypedTestState(),
+            dispatcherConfig = testDispatcherConfig(testDispatcher),
+        )
+        val storeB = KoinMviRetainedStore<TypedTestState, TypedTestIntention>(
+            features = setOf(feature.wrap()),
+            defaultState = TypedTestState(),
+            dispatcherConfig = testDispatcherConfig(testDispatcher),
+        )
+
+        // Allow feature coroutines to subscribe before dispatching
+        advanceUntilIdle()
+
+        // Act
+        storeA.dispatch(TypedTestIntention.Increment)
+        advanceUntilIdle()
+
+        // Assert — storeB's state is unaffected
+        assertEquals(1, storeA.state.value.count)
+        assertEquals(0, storeB.state.value.count)
+
+        storeA.clear()
+        storeB.clear()
+    }
+}


### PR DESCRIPTION
## Summary

Three related improvements to the Koin helper:

1. **Cross-navigation sharing** — `koinMviStore()` now accepts a `storeOwner` parameter. Default is `LocalMviStoreOwner.current` (preserves today's behavior). For app-lifetime state across CMP Navigation, wrap your `NavHost` in `ProvideAppMviStoreOwner { ... }` and resolve via `koinMviAppStore<S, I>()`.

2. **Narrower return type** — returns `MviStore<S, I>` (the interface) instead of the concrete `KoinMviRetainedStore`. Callers see only `state`/`effects`/`dispatch`/`clear`.

3. **Typed intention** — `KoinMviRetainedStore<S, I>` is now parameterized by the intention type. Sealed-class intentions get compile-time safe `dispatch(MyIntention.Increment)`.

## Usage

```kotlin
// State + sealed intentions
data class CounterState(val count: Int = 0) : State
sealed class CounterIntention {
    data object Increment : CounterIntention()
}

// Register
val module = module {
    mviStore<CounterState, CounterIntention>(defaultState = CounterState()) {
        add(get<IncrementFeature>())
    }
}

// Resolve, typed
@Composable
fun Screen(
    store: MviStore<CounterState, CounterIntention> = koinMviStore(),
) {
    Button(onClick = { store.dispatch(CounterIntention.Increment) }) { ... }
}

// Share across navigation
@Composable
fun App() {
    ProvideAppMviStoreOwner {
        NavHost(...) {
            composable<Screen1> { Screen() }  // same store below
        }
    }
}

@Composable
fun AuthScreen(
    store: MviStore<AuthState, AuthIntention> = koinMviAppStore(),
) { ... }
```

## API surface cleanup

- Added `typealias MviStoreOwner = ViewModelStoreOwner` in `:yamv-koin` so public APIs don't leak ViewModel terminology.
- Added `LocalMviStoreOwner` mirroring `LocalViewModelStoreOwner` with the aliased type.

## Breaking changes (pre-1.0)

- `mviStore<S>(...)` → `mviStore<S, I>(...)`
- `koinMviStore<S>()` → `koinMviStore<S, I>()`
- `KoinMviRetainedStore<S>` → `KoinMviRetainedStore<S, I>`

Callers who don't care about intention typing: pass `Any` for `I`.

## Out of scope

Typing Hilt-generated stores by intention requires `@AutoState(intention = ...)` and KSP processor changes — will be a separate issue.

## Test plan
- [x] `./gradlew :yamv-koin:test` passes (updated existing tests + new `KoinMviStoreScopeTest`)
- [x] `./gradlew :app:koin:build` passes (sample uses new typed signatures)
- [x] `./gradlew detektAll` passes

Closes #41