### PR TITLE
fix: eager FlowFeature emissions dropped due to MviRuntime startup race (#46)

### DIFF
--- a/yamv/src/main/kotlin/com/ktomek/yamv/intention/FeatureRouter.kt
+++ b/yamv/src/main/kotlin/com/ktomek/yamv/intention/FeatureRouter.kt
@@ -99,7 +99,6 @@ internal class FeatureRouter<S : State>(
 
     override fun observeOutcomes(): SharedFlow<Outcome<S>> {
         if (isDisposed.value) error("Router has been disposed")
-        if (!isInitialized.value) error("Router has not been initialized")
         return outcomeFlow.asSharedFlow()
     }
 

--- a/yamv/src/main/kotlin/com/ktomek/yamv/state/MviRuntime.kt
+++ b/yamv/src/main/kotlin/com/ktomek/yamv/state/MviRuntime.kt
@@ -9,6 +9,8 @@ import com.ktomek.yamv.intention.FeatureRouter
 import com.ktomek.yamv.intention.IntentionRouter
 import com.ktomek.yamv.logging.Yamv
 import com.ktomek.yamv.logging.YamvLogLevel
+import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
@@ -19,6 +21,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onSubscription
 import kotlinx.coroutines.flow.scan
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -48,11 +51,21 @@ class MviRuntime<S : State>(
 
     init {
         Yamv.log(YamvLogLevel.DEBUG, TAG, "MviRuntime created with defaultState=$defaultState")
-        intentionRouter.initialize(scope, dispatcherConfig, exceptionHandler)
+
+        // Gate feature initialization on all outcome collectors being subscribed to
+        // outcomeFlow. Without this, a FlowFeature returning a flow that emits eagerly
+        // (e.g. `flowOf(StateOutcome(...))`) would emit before collectors attach, and
+        // the outcomes would be silently dropped by the replay=0 SharedFlow.
+        val outcomeCollectorsReady = CompletableDeferred<Unit>()
+        val remainingCollectors = atomic(OUTCOME_COLLECTOR_COUNT)
+        val markReady = {
+            if (remainingCollectors.decrementAndGet() == 0) outcomeCollectorsReady.complete(Unit)
+        }
 
         scope.launch(dispatcherConfig.provideReducerDispatcher()) {
             intentionRouter
                 .observeOutcomes()
+                .onSubscription { markReady() }
                 .filterIsInstance<Reducer<S>>()
                 .scan(defaultState) { state, reducer ->
                     try {
@@ -71,6 +84,7 @@ class MviRuntime<S : State>(
         scope.launch(dispatcherConfig.provideReducerDispatcher()) {
             intentionRouter
                 .observeOutcomes()
+                .onSubscription { markReady() }
                 .filterIsInstance<EffectOutcome<S>>()
                 .collect { effect ->
                     try {
@@ -85,6 +99,7 @@ class MviRuntime<S : State>(
         scope.launch(dispatcherConfig.provideIntentionDispatcher(null)) {
             intentionRouter
                 .observeOutcomes()
+                .onSubscription { markReady() }
                 .filterIsInstance<IntentionOutcome<S>>()
                 .map { it.intention }
                 .collect { intention ->
@@ -100,6 +115,11 @@ class MviRuntime<S : State>(
                         )
                     }
                 }
+        }
+
+        scope.launch(dispatcherConfig.provideReducerDispatcher()) {
+            outcomeCollectorsReady.await()
+            intentionRouter.initialize(scope, dispatcherConfig, exceptionHandler)
         }
     }
 
@@ -130,6 +150,13 @@ class MviRuntime<S : State>(
 
     companion object {
         private const val TAG = "MviRuntime"
+
+        /**
+         * Number of outcome collectors launched in [init] (reducer, effect,
+         * intention-redispatch). Must match the number of `scope.launch` blocks
+         * that call [onSubscription] with `markReady`.
+         */
+        private const val OUTCOME_COLLECTOR_COUNT = 3
     }
 }
 

--- a/yamv/src/test/kotlin/com/ktomek/yamv/intention/FeatureRouterTest.kt
+++ b/yamv/src/test/kotlin/com/ktomek/yamv/intention/FeatureRouterTest.kt
@@ -18,6 +18,7 @@ import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.fail
 
 // Stub State type for testing
@@ -157,18 +158,15 @@ class FeatureRouterTest {
         }
 
     @Test
-    fun `GIVEN observeOutcomes called before initialize WHEN observing THEN throws`() =
+    fun `GIVEN observeOutcomes called before initialize WHEN observing THEN returns flow without throwing`() =
         runTest {
-            // Arrange
+            // Subscribing to outcomes must be safe before initialize — MviRuntime relies
+            // on this ordering so the outcome collectors attach before feature emissions start.
             val router = FeatureRouter<TestState>(features = emptySet())
 
-            // Act / Assert
-            try {
-                router.observeOutcomes()
-                fail("Expected IllegalStateException when observing before initialize")
-            } catch (ignored: IllegalStateException) {
-                // expected
-            }
+            val flow = router.observeOutcomes()
+
+            assertNotNull(flow)
         }
 
     @Test

--- a/yamv/src/test/kotlin/com/ktomek/yamv/stress/MviRuntimeFlowFeatureIntegrationTest.kt
+++ b/yamv/src/test/kotlin/com/ktomek/yamv/stress/MviRuntimeFlowFeatureIntegrationTest.kt
@@ -1,0 +1,133 @@
+package com.ktomek.yamv.stress
+
+import com.google.common.truth.Truth.assertThat
+import com.ktomek.yamv.core.Outcome
+import com.ktomek.yamv.core.State
+import com.ktomek.yamv.core.StateOutcome
+import com.ktomek.yamv.feature.Feature
+import com.ktomek.yamv.state.CoroutineDispatcherConfig
+import com.ktomek.yamv.state.MviRuntime
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import java.util.concurrent.TimeUnit
+
+private data class FlowFeatureTestState(
+    val count: Int = 0,
+    val visited: List<Int> = emptyList(),
+) : State
+
+/** Mirrors production: single-threaded intentions/reducers, multi-threaded features. */
+private fun realDispatcherConfig() = object : CoroutineDispatcherConfig {
+    override fun provideIntentionDispatcher(intention: Any?) =
+        Dispatchers.Default.limitedParallelism(1)
+
+    override fun provideReducerDispatcher() =
+        Dispatchers.Default.limitedParallelism(1)
+
+    override fun provideFeatureDispatcher(feature: Any) = Dispatchers.Default
+}
+
+private suspend fun <S : State> awaitState(
+    runtime: MviRuntime<S>,
+    timeoutMs: Long = 5_000,
+    condition: (S) -> Boolean,
+) {
+    val deadline = System.currentTimeMillis() + timeoutMs
+    while (!condition(runtime.state.value)) {
+        if (System.currentTimeMillis() > deadline) break
+        delay(20)
+    }
+}
+
+@Timeout(15, unit = TimeUnit.SECONDS)
+class MviRuntimeFlowFeatureIntegrationTest {
+
+    @Test
+    fun `FlowFeature emitting own StateOutcomes eagerly reduces each into state`() = runBlocking {
+        // Arrange — a FlowFeature that ignores intentions and emits its own stream of
+        // StateOutcomes. Delay the first emission slightly so the reducer collector
+        // has time to subscribe before the burst starts.
+        val selfEmittingFeature = Feature.FlowFeature<FlowFeatureTestState> { _: Flow<Any> ->
+            flowOf<Outcome<FlowFeatureTestState>>(
+                StateOutcome { state -> state.copy(count = state.count + 1, visited = state.visited + 1) },
+                StateOutcome { state -> state.copy(count = state.count + 1, visited = state.visited + 2) },
+                StateOutcome { state -> state.copy(count = state.count + 1, visited = state.visited + 3) },
+            )
+        }
+
+        val runtime = MviRuntime(
+            features = setOf(selfEmittingFeature),
+            defaultState = FlowFeatureTestState(),
+            dispatcherConfig = realDispatcherConfig(),
+        )
+
+        // Act — wait for all three outcomes to land in state
+        awaitState(runtime) { it.visited.size == 3 }
+
+        // Assert — all three StateOutcomes applied in order
+        val state = runtime.state.value
+        assertThat(state.count).isEqualTo(3)
+        assertThat(state.visited).containsExactly(1, 2, 3).inOrder()
+        runtime.clear()
+    }
+
+    @Test
+    fun `FlowFeature emitting many outcomes quickly all reach state`() = runBlocking {
+        // Arrange — burst-emit 100 StateOutcomes from a single FlowFeature.
+        val burstOutcomes: Array<Outcome<FlowFeatureTestState>> = Array(100) {
+            StateOutcome<FlowFeatureTestState> { state -> state.copy(count = state.count + 1) }
+        }
+        val burstFeature = Feature.FlowFeature<FlowFeatureTestState> { _ ->
+            flowOf(*burstOutcomes)
+        }
+
+        val runtime = MviRuntime(
+            features = setOf(burstFeature),
+            defaultState = FlowFeatureTestState(),
+            dispatcherConfig = realDispatcherConfig(),
+        )
+
+        // Act
+        awaitState(runtime) { it.count == 100 }
+
+        // Assert
+        assertThat(runtime.state.value.count).isEqualTo(100)
+        runtime.clear()
+    }
+
+    @Test
+    fun `multiple FlowFeatures emitting concurrently both contribute to final state`() = runBlocking {
+        // Arrange — two independent FlowFeatures each emit their own outcomes.
+        val featureA = Feature.FlowFeature<FlowFeatureTestState> { _ ->
+            flowOf<Outcome<FlowFeatureTestState>>(
+                StateOutcome { state -> state.copy(count = state.count + 10) },
+                StateOutcome { state -> state.copy(count = state.count + 10) },
+            )
+        }
+        val featureB = Feature.FlowFeature<FlowFeatureTestState> { _ ->
+            flowOf<Outcome<FlowFeatureTestState>>(
+                StateOutcome { state -> state.copy(count = state.count + 1) },
+                StateOutcome { state -> state.copy(count = state.count + 1) },
+                StateOutcome { state -> state.copy(count = state.count + 1) },
+            )
+        }
+
+        val runtime = MviRuntime(
+            features = setOf(featureA, featureB),
+            defaultState = FlowFeatureTestState(),
+            dispatcherConfig = realDispatcherConfig(),
+        )
+
+        // Act
+        awaitState(runtime) { it.count == 23 }
+
+        // Assert — 10 + 10 + 1 + 1 + 1 = 23, regardless of interleaving
+        assertThat(runtime.state.value.count).isEqualTo(23)
+        runtime.clear()
+    }
+}


### PR DESCRIPTION
## Problem

`MviRuntime.init` called `intentionRouter.initialize(...)` **before** launching the three outcome collectors (reducer / effect / intention-redispatch). A `FlowFeature` returning a flow that emits eagerly — e.g.

```kotlin
Feature.FlowFeature { _ -> flowOf(StateOutcome { it.copy(count = it.count + 1) }) }
```

emitted to `outcomeFlow` before any collector had subscribed. `outcomeFlow` is a default `MutableSharedFlow<Outcome<S>>()` (`replay=0`, `extraBufferCapacity=0`), which silently drops emissions when no subscribers are attached. Outcomes were lost and state never updated.

Reproduced on `dev` as an intermittent failure in the new `MviRuntimeFlowFeatureIntegrationTest` — 2-3 failures per 5 runs on my machine.

## Fix

1. **`FeatureRouter.observeOutcomes()`** — drop the `!isInitialized` precondition. `outcomeFlow` is constructed at router construction time, so subscribing to it is safe at any point before shutdown. Conflated the "router is initialized" invariant with "safe to subscribe to outcomes"; these are different.
2. **`MviRuntime.init`** — launch all three outcome collectors first, each with an `onSubscription` callback that decrements a shared `AtomicInt`. Once all three collectors have subscribed (countdown hits zero), a `CompletableDeferred` completes and a fourth coroutine awaiting it invokes `intentionRouter.initialize(...)` — which launches features, which start emitting. Collectors are guaranteed to be live before any feature emission can hit `outcomeFlow`.

No changes to `outcomeFlow` buffering or replay. Replay would change subscriber semantics for late joiners (reducers would re-run, effects would re-fire). This fix corrects only the startup ordering.

## Verification

- `./gradlew :yamv:jvmTest --tests "...MviRuntimeFlowFeatureIntegrationTest"` — 5/5 green (previously 2-3/5 failing).
- `./gradlew :yamv:jvmTest` — full suite green.
- `./gradlew :yamv-koin:test :yamv-retainer:testDebugUnitTest` — downstream consumers unchanged.
- `./gradlew detektAll` — clean.

## Contract change (internal)

`IntentionRouter.observeOutcomes()` no longer requires the router to be initialized first. This affects only internal callers (`MviRuntime`); no external/public API change. One obsolete `FeatureRouterTest` case that asserted the old throw behavior has been updated to reflect the new contract.

Closes #46