### PR TITLE
chore: update publishableModules with yamv-prefixed names (#48)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,13 +33,13 @@ allprojects {
 
 // Publishing configuration for library modules
 val publishableModules = setOf(
-    "core",
+    "yamv-core",
     "yamv",
     "yamv-retainer",
     "yamv-hilt",
     "yamv-koin",
-    "processor-core",
-    "processor-hilt"
+    "yamv-processor-core",
+    "yamv-processor-hilt"
 )
 
 subprojects {


### PR DESCRIPTION
## Problem

Follow-up to #37 / #38 (module rename). The root \`build.gradle.kts\` \`publishableModules\` set gates which subprojects get the vanniktech maven-publish plugin and Dokka applied:

\`\`\`kotlin
subprojects {
    if (name in publishableModules) {
        apply(plugin = "com.vanniktech.maven.publish")
        apply(plugin = "org.jetbrains.dokka")
        ...
    }
}
\`\`\`

After the rename, the set still listed the pre-rename names (\`core\`, \`processor-core\`, \`processor-hilt\`). No subproject matches those anymore, so the publishing plugin silently wasn't applied to \`yamv-core\`, \`yamv-processor-core\`, or \`yamv-processor-hilt\`. A publish run would skip those three modules.

## Fix

One-line set update. Verified locally with a \`publishToMavenLocal --dry-run\` targeting the renamed modules — publishing tasks are now registered where previously they didn't exist.

Closes #48