### PR TITLE
[#50] feat: add TypedUnitFeature typed wrapper for FlowUnitFeature

### DIFF
--- a/yamv-koin/src/commonMain/kotlin/com/ktomek/yamv/koin/FeatureRegistrar.kt
+++ b/yamv-koin/src/commonMain/kotlin/com/ktomek/yamv/koin/FeatureRegistrar.kt
@@ -5,6 +5,7 @@ import com.ktomek.yamv.feature.ActionTypedFeature
 import com.ktomek.yamv.feature.Feature
 import com.ktomek.yamv.feature.FunctionTypedFeature
 import com.ktomek.yamv.feature.TypedFeature
+import com.ktomek.yamv.feature.TypedUnitFeature
 import com.ktomek.yamv.feature.wrap
 import org.koin.core.scope.Scope
 
@@ -12,8 +13,8 @@ import org.koin.core.scope.Scope
  * Builder that assembles a [Set]<[Feature]<[S]>> for use in [mviStore].
  *
  * Call [add] for each feature. For typed feature interfaces ([FunctionTypedFeature],
- * [ActionTypedFeature], [TypedFeature]) the required `.wrap()` is applied automatically —
- * no call sites need to know about it.
+ * [ActionTypedFeature], [TypedFeature], [TypedUnitFeature]) the required `.wrap()` is applied
+ * automatically — no call sites need to know about it.
  *
  * Koin dependency resolution is forwarded via the inline [get] function, keeping the same
  * ergonomics as a plain `Scope.() -> ...` lambda.
@@ -39,6 +40,11 @@ class FeatureRegistrar<S : State>(@PublishedApi internal val scope: Scope) {
 
     /** Adds a [TypedFeature], applying [wrap] internally. */
     inline fun <reified I : Any> add(feature: TypedFeature<S, I>) {
+        features.add(feature.wrap())
+    }
+
+    /** Adds a [TypedUnitFeature], applying [wrap] internally. */
+    inline fun <reified I : Any> add(feature: TypedUnitFeature<S, I>) {
         features.add(feature.wrap())
     }
 

--- a/yamv/src/main/kotlin/com/ktomek/yamv/feature/TypedFeature.kt
+++ b/yamv/src/main/kotlin/com/ktomek/yamv/feature/TypedFeature.kt
@@ -28,3 +28,16 @@ interface TypedFeatureHolder<S : State> : Feature.FlowFeature<S> {
 interface TypedUnitFeatureHolder<S : State> : Feature.FlowFeature<S> {
     val feature: Any
 }
+
+/**
+ * Typed counterpart of [Feature.FlowUnitFeature]: receives a strongly-typed [Flow] of intentions
+ * and produces a [Flow] of [Unit] (fire-and-forget side effects, no state contribution).
+ *
+ * Use [wrap] to turn a [TypedUnitFeature] into a [Feature] that the runtime can dispatch.
+ *
+ * @param S The state type the owning store works with.
+ * @param INTENTION The intention type this feature reacts to.
+ */
+fun interface TypedUnitFeature<S : State, INTENTION> {
+    operator fun invoke(intention: Flow<INTENTION>): Flow<Unit>
+}

--- a/yamv/src/main/kotlin/com/ktomek/yamv/feature/TypedUnitFeatureWrapper.kt
+++ b/yamv/src/main/kotlin/com/ktomek/yamv/feature/TypedUnitFeatureWrapper.kt
@@ -1,0 +1,13 @@
+package com.ktomek.yamv.feature
+
+import com.ktomek.yamv.core.State
+import kotlinx.coroutines.flow.channelFlow
+import kotlinx.coroutines.flow.filterIsInstance
+
+inline fun <S : State, reified INTENTION> TypedUnitFeature<S, INTENTION>.wrap(): Feature<S> =
+    Feature.FlowUnitFeature<S> { intentions ->
+        channelFlow {
+            val typedIntentions = intentions.filterIsInstance<INTENTION>()
+            this@wrap.invoke(typedIntentions).collect(::send)
+        }
+    }

--- a/yamv/src/test/kotlin/com/ktomek/yamv/feature/TypedUnitFeatureWrapperTest.kt
+++ b/yamv/src/test/kotlin/com/ktomek/yamv/feature/TypedUnitFeatureWrapperTest.kt
@@ -1,0 +1,99 @@
+package com.ktomek.yamv.feature
+
+import com.google.common.truth.Truth.assertThat
+import com.ktomek.yamv.core.State
+import com.ktomek.yamv.state.DefaultCoroutineDispatcherConfig
+import com.ktomek.yamv.state.MviRuntime
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+private data class UnitTestState(val count: Int = 0) : State
+private data class TypedDoAction(val id: String)
+private data class TypedOtherAction(val id: String)
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TypedUnitFeatureWrapperTest {
+
+    @Test
+    fun `wrap produces a FlowUnitFeature`() {
+        val feature = TypedUnitFeature<UnitTestState, TypedDoAction> { intentions ->
+            intentions.map { }
+        }.wrap()
+        assertThat(feature).isInstanceOf(Feature.FlowUnitFeature::class.java)
+        assertThat(feature).isNotInstanceOf(Feature.FlowFeature::class.java)
+    }
+
+    @Test
+    fun `matching intentions are passed to the typed flow`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val received = mutableListOf<String>()
+
+        val feature = TypedUnitFeature<UnitTestState, TypedDoAction> { intentions ->
+            intentions.onEach { received.add(it.id) }.map { }
+        }.wrap()
+
+        val runtime = MviRuntime(
+            features = setOf(feature),
+            defaultState = UnitTestState(),
+            dispatcherConfig = DefaultCoroutineDispatcherConfig(dispatcher, dispatcher),
+        )
+
+        testScheduler.advanceUntilIdle()
+        runtime.dispatch(TypedDoAction("a"))
+        runtime.dispatch(TypedDoAction("b"))
+        testScheduler.advanceUntilIdle()
+
+        assertThat(received).containsExactly("a", "b").inOrder()
+        runtime.clear()
+    }
+
+    @Test
+    fun `non-matching intentions are filtered out`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val received = mutableListOf<String>()
+
+        val feature = TypedUnitFeature<UnitTestState, TypedDoAction> { intentions ->
+            intentions.onEach { received.add(it.id) }.map { }
+        }.wrap()
+
+        val runtime = MviRuntime(
+            features = setOf(feature),
+            defaultState = UnitTestState(),
+            dispatcherConfig = DefaultCoroutineDispatcherConfig(dispatcher, dispatcher),
+        )
+
+        testScheduler.advanceUntilIdle()
+        runtime.dispatch(TypedOtherAction("ignored"))
+        runtime.dispatch(TypedDoAction("kept"))
+        testScheduler.advanceUntilIdle()
+
+        assertThat(received).containsExactly("kept")
+        runtime.clear()
+    }
+
+    @Test
+    fun `state is unchanged because no Outcome is emitted`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+
+        val feature = TypedUnitFeature<UnitTestState, TypedDoAction> { intentions ->
+            intentions.map { }
+        }.wrap()
+
+        val runtime = MviRuntime(
+            features = setOf(feature),
+            defaultState = UnitTestState(count = 7),
+            dispatcherConfig = DefaultCoroutineDispatcherConfig(dispatcher, dispatcher),
+        )
+
+        testScheduler.advanceUntilIdle()
+        runtime.dispatch(TypedDoAction("a"))
+        testScheduler.advanceUntilIdle()
+
+        assertThat(runtime.state.value.count).isEqualTo(7)
+        runtime.clear()
+    }
+}


### PR DESCRIPTION
Closes #50.

## Summary
- Adds `TypedUnitFeature<S, INTENTION>` fun-interface in `feature/TypedFeature.kt` — typed counterpart of `Feature.FlowUnitFeature`.
- Adds `TypedUnitFeature.wrap()` in new `TypedUnitFeatureWrapper.kt`, returning a real `Feature.FlowUnitFeature<S>` so `FeatureRouter.processFeature` routes it through the unit branch (no holder needed).
- Adds matching `FeatureRegistrar.add(TypedUnitFeature<S, I>)` overload in `yamv-koin` so Koin call-sites get auto-wrapping like the other typed shapes.
- New `TypedUnitFeatureWrapperTest` covers wrap type, intention filtering by reified `INTENTION`, and that no `Outcome` is emitted (state unchanged).

## Out of scope
- Hilt KSP class-level `@AutoFeature` parity — tracked in #51 and depends on this PR.

## Test plan
- [x] `./gradlew :yamv:jvmTest --tests "com.ktomek.yamv.feature.TypedUnitFeatureWrapperTest"`
- [x] `./gradlew :yamv:jvmTest :yamv-koin:testDebugUnitTest detektAll`
- [x] `./gradlew build`