### PR TITLE
[#51] feat: hilt KSP supports @AutoFeature on all typed feature shapes

### DIFF
--- a/yamv-processor-hilt/src/main/kotlin/com/ktomek/yamv/processor/hilt/FeatureFilter.kt
+++ b/yamv-processor-hilt/src/main/kotlin/com/ktomek/yamv/processor/hilt/FeatureFilter.kt
@@ -14,8 +14,10 @@ import com.squareup.kotlinpoet.ksp.toClassName
 internal class FeatureFilter(private val resolver: Resolver) {
 
     /**
-     * Returns all valid `@AutoFeature` declarations that are recognized feature types
-     * (either [FeatureFqns.FLOW_FEATURE] classes or [FeatureFqns.FUNCTION_TYPED_FEATURE] classes/properties).
+     * Returns all valid `@AutoFeature` declarations that are recognized feature types —
+     * any direct [Feature][FeatureFqns.FEATURE] subtype (for classes: [FeatureFqns.FLOW_FEATURE] or
+     * [FeatureFqns.FLOW_UNIT_FEATURE]) or any of the typed feature wrappers
+     * ([FeatureFqns.WRAP_REQUIRED]).
      */
     fun findAll(): List<KSDeclaration> {
         val classes = AutoFeatureDiscovery.findAnnotatedClasses(resolver).filter { it.isKnownFeatureClass() }
@@ -47,13 +49,14 @@ internal class FeatureFilter(private val resolver: Resolver) {
         resolve().arguments.firstOrNull()?.type?.resolve()?.declaration?.simpleName?.asString() == stateName
 
     companion object {
-        private val KNOWN_CLASS_FEATURE_FQNS = setOf(
-            FeatureFqns.FLOW_FEATURE,
-            FeatureFqns.FUNCTION_TYPED_FEATURE,
-        )
-        private val KNOWN_PROPERTY_FEATURE_FQNS = setOf(
-            FeatureFqns.FUNCTION_TYPED_FEATURE,
-            FeatureFqns.FEATURE,
-        )
+        private val KNOWN_CLASS_FEATURE_FQNS: Set<String> = buildSet {
+            add(FeatureFqns.FLOW_FEATURE)
+            add(FeatureFqns.FLOW_UNIT_FEATURE)
+            addAll(FeatureFqns.WRAP_REQUIRED)
+        }
+        private val KNOWN_PROPERTY_FEATURE_FQNS: Set<String> = buildSet {
+            add(FeatureFqns.FEATURE)
+            addAll(FeatureFqns.WRAP_REQUIRED)
+        }
     }
 }

--- a/yamv-processor-hilt/src/main/kotlin/com/ktomek/yamv/processor/hilt/FeaturesModuleGenerator.kt
+++ b/yamv-processor-hilt/src/main/kotlin/com/ktomek/yamv/processor/hilt/FeaturesModuleGenerator.kt
@@ -76,9 +76,12 @@ internal class FeaturesModuleGenerator(private val codeGenerator: CodeGenerator)
             .build()
     }
 
-    /** Returns true if this class feature needs `.wrap()` (i.e. it is a FunctionTypedFeature). */
+    /**
+     * Returns true if this class feature needs `.wrap()` — i.e. it implements one of the typed
+     * feature interfaces ([FeatureFqns.WRAP_REQUIRED]) rather than `Feature<S>` directly.
+     */
     private fun KSClassDeclaration.requiresWrap(): Boolean =
-        superTypes.any { it.resolve().declaration.qualifiedName?.asString() == FeatureFqns.FUNCTION_TYPED_FEATURE }
+        superTypes.any { it.resolve().declaration.qualifiedName?.asString() in FeatureFqns.WRAP_REQUIRED }
 
     private fun buildInstallInAnnotation(): AnnotationSpec =
         AnnotationSpec.builder(HiltClassNames.InstallIn)

--- a/yamv-processor-hilt/src/main/kotlin/com/ktomek/yamv/processor/hilt/HiltClassNames.kt
+++ b/yamv-processor-hilt/src/main/kotlin/com/ktomek/yamv/processor/hilt/HiltClassNames.kt
@@ -32,8 +32,18 @@ internal object YamvClassNames {
 internal object FeatureFqns {
     const val FEATURE = "com.ktomek.yamv.feature.Feature"
     const val FLOW_FEATURE = "com.ktomek.yamv.feature.Feature.FlowFeature"
+    const val FLOW_UNIT_FEATURE = "com.ktomek.yamv.feature.Feature.FlowUnitFeature"
     const val FUNCTION_TYPED_FEATURE = "com.ktomek.yamv.feature.FunctionTypedFeature"
     const val TYPED_FEATURE = "com.ktomek.yamv.feature.TypedFeature"
+    const val ACTION_TYPED_FEATURE = "com.ktomek.yamv.feature.ActionTypedFeature"
+    const val TYPED_UNIT_FEATURE = "com.ktomek.yamv.feature.TypedUnitFeature"
+
+    val WRAP_REQUIRED: Set<String> = setOf(
+        FUNCTION_TYPED_FEATURE,
+        TYPED_FEATURE,
+        ACTION_TYPED_FEATURE,
+        TYPED_UNIT_FEATURE,
+    )
 }
 
 internal const val NO_DEFAULT_STATE_NAME = "NoDefaultState"


### PR DESCRIPTION
Closes #51.

## Summary
The class-level `@AutoFeature` path only handled `FlowFeature` and `FunctionTypedFeature`:

- `FeatureFilter.KNOWN_CLASS_FEATURE_FQNS` silently dropped `TypedFeature` / `ActionTypedFeature` / `TypedUnitFeature` (and `FlowUnitFeature`) at discovery time.
- Even when reached, `FeaturesModuleGenerator.requiresWrap()` only matched `FunctionTypedFeature` — anything else fell into the `@Binds` path, which only compiles for direct `Feature<S>` subtypes.

This PR routes all four typed shapes through `@Provides … = it.wrap()`, and recognizes `FlowUnitFeature` at the class level (bound via `@Binds` since it already extends `Feature`).

### Changes
- `HiltClassNames.kt` — add `FLOW_UNIT_FEATURE`, `ACTION_TYPED_FEATURE`, `TYPED_UNIT_FEATURE` FQNs, plus `WRAP_REQUIRED: Set<String>` as the single source of truth for "needs `.wrap()`".
- `FeatureFilter.kt` — discovery sets now include all wrap-needing shapes plus `FlowUnitFeature` for classes.
- `FeaturesModuleGenerator.kt` — `requiresWrap()` checks membership in `WRAP_REQUIRED` instead of equality with `FUNCTION_TYPED_FEATURE`.

### Out of scope
- KSP-level unit tests for the processor — `yamv-processor-hilt` has no test infra today (empty `src/test/kotlin/com/ktomek/yamv/`, no test deps). Tracked separately as #55.

## Test plan
- [x] `./gradlew :yamv-processor-hilt:build`
- [x] `./gradlew :app:hilt:assembleDebug` (sample app's existing `FunctionTypedFeature` and `FlowFeature` paths still process correctly)
- [x] `./gradlew detektAll`
- [x] `./gradlew build` (full multi-module green)