### PR TITLE
[#53] docs: refresh README, CLAUDE.md, and site-docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,11 +32,14 @@ YAMV (Yet Another MVI framework) is a Kotlin-first MVI (Model-View-Intent) archi
 ## Module Structure
 
 - **`:yamv-core`** — Marker interfaces and annotations (`State`, `Outcome` hierarchy, `@AutoState`, `@AutoFeature`)
-- **`:yamv`** — Core framework (pure Kotlin, no Android deps): `MviRuntime`, `MviStore`, `MviRegistry`, `FeatureRouter`, Feature wrappers
-- **`:yamv-retainer`** — Lifecycle-retained MviStore: `MviRetainedStore`, `hiltMviStore()` Compose helper
+- **`:yamv`** — Core framework (Kotlin Multiplatform, no Android deps): `MviRuntime`, `MviStore`, `MviRegistry`, `FeatureRouter`, Feature wrappers
+- **`:yamv-retainer`** — Lifecycle-retained MviStore: `MviRetainedStore` base class
+- **`:yamv-hilt`** — Hilt integration: `hiltMviStore()` Compose helper, `MviDispatcherConfig`
+- **`:yamv-koin`** — Koin integration (KMP): `koinMviStore<S, I>()`, `mviStore {}` DSL, `ProvideAppMviStoreOwner`
 - **`:yamv-processor-core`** — DI-agnostic KSP utilities: `AutoStateDiscovery`, `AutoFeatureDiscovery`
 - **`:yamv-processor-hilt`** — Hilt-specific KSP processor: generates `*Store` retained stores and `*FeaturesModule` Hilt modules
-- **`:app`** — Counter demo app showing framework usage end-to-end
+- **`:yamv-processor-hilt-fixtures`** — KSP coverage fixtures (not published) — synthetic `@AutoState`/`@AutoFeature` per feature shape, with assertions on the generated module
+- **`:app:hilt`** / **`:app:koin`** / **`:app:koin-android`** / **`:app:common`** — counter demo apps end-to-end (Hilt, Koin Android, Koin Multiplatform)
 
 ## Architecture
 
@@ -63,10 +66,12 @@ StateFlow<S> (observed by UI)
 - `EffectOutcome<S>` — side effect marker
 - `IntentionOutcome<S>` — triggers another intention dispatch
 
-**Features** — three levels of abstraction:
-- `Feature<S>` (sealed) — low-level, untyped `Flow<Any> → Flow<Outcome<S>>`
-- `TypedFeature<S, I>` — typed intentions `Flow<I> → Flow<Outcome<S>>`; use `.wrap()` to convert to `Feature<S>`
-- `FunctionTypedFeature<S, I>` — single-intention handler `(I) -> Outcome<S>`; use `functionTypedFeature<S, I> { }` builder
+**Features** — sealed `Feature<S>` has two raw shapes (`Feature.FlowFeature<S>` returning `Flow<Outcome<S>>`, `Feature.FlowUnitFeature<S>` returning `Flow<Unit>` for fire-and-forget). Four typed wrappers cover the common cases — call `.wrap()` to convert to `Feature<S>` (automatic with `@AutoFeature` / Koin `mviStore { add(…) }`):
+
+- `TypedFeature<S, I>` — typed `Flow<I> → Flow<Outcome<S>>` (wraps to `FlowFeature`)
+- `FunctionTypedFeature<S, I>` — single-intention `suspend (I) -> Outcome<S>` (wraps to `FlowFeature`); also `functionTypedFeature<S, I> { }` builder
+- `ActionTypedFeature<S, I>` — single-intention `suspend (I) -> Unit` (wraps to a unit holder)
+- `TypedUnitFeature<S, I>` — typed `Flow<I> → Flow<Unit>` (wraps to `FlowUnitFeature`)
 
 **Dispatcher Strategy** (`CoroutineDispatcherConfig`):
 - Intentions & Reducers → `Dispatchers.Main`

--- a/README.md
+++ b/README.md
@@ -125,6 +125,17 @@ class IncrementFeature : TypedFeature<CounterState, CounterIntention.Increment> 
 }
 ```
 
+YAMV provides four typed feature shapes — pick the simplest that fits:
+
+| Shape | Signature | Best for |
+|---|---|---|
+| `FunctionTypedFeature<S, I>` | `suspend (I) -> Outcome<S>` | One outcome per intention |
+| `TypedFeature<S, I>` | `Flow<I> -> Flow<Outcome<S>>` | Stream transforms (`flatMapMerge`, `flatMapLatest`, …) |
+| `ActionTypedFeature<S, I>` | `suspend (I) -> Unit` | Fire-and-forget side effects, no state contribution |
+| `TypedUnitFeature<S, I>` | `Flow<I> -> Flow<Unit>` | Streamed side effects, no state contribution |
+
+All four call `.wrap()` when bound — automatically with `@AutoFeature` (Hilt) or the Koin `mviStore { add(…) }` DSL, manually otherwise.
+
 ### 4. Collect state in your Composable
 
 ```kotlin

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,8 @@ markdown_extensions:
           format: !!python/name:pymdownx.superfences.fence_code_format
   - admonition
   - pymdownx.details
+  - pymdownx.tabbed:
+      alternate_style: true
   - attr_list
 
 nav:

--- a/site-docs/architecture.md
+++ b/site-docs/architecture.md
@@ -38,15 +38,18 @@ Declare outcome subclasses as **standalone classes** — they are decoupled from
 
 ## Feature Abstraction Levels
 
-Three abstraction levels (choose the simplest one that fits):
+Sealed `Feature<S>` has two raw shapes; four typed wrappers cover the common cases. Choose the simplest one that fits:
 
 | Type | API | When to use |
 |------|-----|-------------|
-| `Feature.FlowFeature<S>` | `(Flow<Any>) -> Flow<Outcome<S>>` | Low-level; handles multiple intention types |
-| `TypedFeature<S, I>` | `(Flow<I>) -> Flow<Outcome<S>>` | Typed; one feature per intention type |
-| `FunctionTypedFeature<S, I>` | `suspend (I) -> Outcome<S>` | Simplest; one outcome per intention |
+| `Feature.FlowFeature<S>` | `(Flow<Any>) -> Flow<Outcome<S>>` | Low-level; multi-intention or untyped |
+| `Feature.FlowUnitFeature<S>` | `(Flow<Any>) -> Flow<Unit>` | Low-level fire-and-forget (no state contribution) |
+| `TypedFeature<S, I>` | `(Flow<I>) -> Flow<Outcome<S>>` | Typed stream → outcomes |
+| `FunctionTypedFeature<S, I>` | `suspend (I) -> Outcome<S>` | One outcome per intention |
+| `ActionTypedFeature<S, I>` | `suspend (I) -> Unit` | One side effect per intention, no state contribution |
+| `TypedUnitFeature<S, I>` | `(Flow<I>) -> Flow<Unit>` | Typed streamed side effects, no state contribution |
 
-Use `.wrap()` to convert `TypedFeature` or `FunctionTypedFeature` to `Feature<S>` when wiring manually. With `@AutoFeature` (Hilt) or `mviStore {}` DSL (Koin), wrapping is automatic.
+All four typed wrappers call `.wrap()` to become a `Feature<S>` — automatic with `@AutoFeature` (Hilt) or the Koin `mviStore { add(…) }` DSL, manual otherwise.
 
 Use `functionTypedFeature<S, I> { }` builder for inline definitions.
 

--- a/site-docs/changelog.md
+++ b/site-docs/changelog.md
@@ -3,9 +3,20 @@
 ## [Unreleased]
 
 ### Added
-- `MviExceptionHandler` — customizable exception handling for the MVI pipeline with fail-fast default
-- `MviErrorContext` / `ErrorSource` — structured error context (source, intention, feature)
-- Lifecycle and concurrency stress tests for `MviRuntime`
+- `TypedUnitFeature<S, I>` — typed counterpart of `Feature.FlowUnitFeature` for streaming side effects with no state contribution; `.wrap()` produces a real `FlowUnitFeature` (#50, #52).
+- Hilt KSP processor now supports `@AutoFeature` on all typed feature shapes — `TypedFeature`, `ActionTypedFeature`, `TypedUnitFeature` were previously dropped at discovery (#51, #56).
+- Typed `koinMviStore<S, I>()` with cross-navigation sharing via `ProvideAppMviStoreOwner` and `koinMviAppStore<S, I>()` (#41, #44).
+- `:yamv-processor-hilt-fixtures` — KSP coverage fixtures asserting the binding decision (`@Binds` vs `@Provides … = it.wrap()`) for every recognized feature shape (#55, #58).
+- `MviExceptionHandler` — customizable exception handling for the MVI pipeline with fail-fast default.
+- `MviErrorContext` / `ErrorSource` — structured error context (source, intention, feature).
+- Lifecycle and concurrency stress tests for `MviRuntime`.
+
+### Changed
+- Publishing migrated from JitPack to Maven Central; coordinates are now `io.github.ktomek:<artifact>:VERSION` (#35, #36).
+- Modules renamed with `yamv-` prefix: `core` → `yamv-core`, `processor-core` → `yamv-processor-core`, `processor-hilt` → `yamv-processor-hilt` (#37, #38, #48, #49).
+
+### Fixed
+- Eager `FlowFeature` emissions were dropped due to an `MviRuntime` startup race; `FeatureRouter` now blocks the first dispatch until every feature has subscribed (#46, #47).
 
 ## [0.1.0] — Initial Release
 

--- a/site-docs/code-generation.md
+++ b/site-docs/code-generation.md
@@ -46,20 +46,22 @@ class IncrementFeature : TypedFeature<CounterState, CounterIntention.Increment> 
 @Module
 @InstallIn(ViewModelComponent::class)
 interface CounterStateFeaturesModule {
+    // Direct Feature<S> subtypes (FlowFeature, FlowUnitFeature) are bound abstractly:
     @Binds @IntoSet @ViewModelScoped
-    fun bindIncrementFeature(feature: IncrementFeature): Feature<CounterState>
+    fun bindsAutoIncreaseFeature(it: AutoIncreaseFeature): Feature<CounterState>
 
     @BindsOptionalOf @MviDispatcherConfig(CounterState::class)
     fun bindOptionalDispatcherConfig(): CoroutineDispatcherConfig
 
-    // @Multibinds declares the empty set so Dagger doesn't fail when no features are bound
-    @Multibinds
-    fun featureSet(): Set<Feature<CounterState>>
-
     companion object {
-        // FunctionTypedFeature classes need .wrap() — goes in companion:
+        // Empty-set seed so Dagger doesn't fail when no features are bound:
+        @Provides @ElementsIntoSet @ViewModelScoped
+        fun provideDefaults(): Set<Feature<CounterState>> = emptySet()
+
+        // Typed feature classes (TypedFeature, FunctionTypedFeature, ActionTypedFeature,
+        // TypedUnitFeature) need .wrap() — they go in the companion object:
         @Provides @IntoSet @ViewModelScoped
-        fun provideDecreaseFeature(it: DecreaseFeature): Feature<CounterState> = it.wrap()
+        fun providesIncrementFeature(it: IncrementFeature): Feature<CounterState> = it.wrap()
     }
 }
 ```

--- a/site-docs/features.md
+++ b/site-docs/features.md
@@ -59,7 +59,7 @@ class IncrementFeature : FunctionTypedFeature<CounterState, CounterIntention.Inc
 
 ### Using `.wrap()`
 
-`FunctionTypedFeature` and `TypedFeature` must be converted to `Feature<S>` before passing to `MviRuntime`. If you're **not** using Hilt code generation (`@AutoFeature`) or the Koin `mviStore {}` DSL, call `.wrap()` manually:
+All four typed feature shapes — `FunctionTypedFeature`, `TypedFeature`, `ActionTypedFeature`, `TypedUnitFeature` — must be converted to `Feature<S>` before passing to `MviRuntime`. If you're **not** using Hilt code generation (`@AutoFeature`) or the Koin `mviStore {}` DSL, call `.wrap()` manually:
 
 ```kotlin
 val runtime = MviRuntime(
@@ -105,6 +105,37 @@ class IncrementFeature : TypedFeature<CounterState, CounterIntention.Increment> 
 }
 ```
 
+## ActionTypedFeature — typed fire-and-forget
+
+For typed side effects that contribute *no* state — analytics, logging, navigation triggers:
+
+```kotlin
+class TrackEventFeature(
+    private val analytics: Analytics,
+) : ActionTypedFeature<AppState, AppIntention.Track> {
+    override suspend fun invoke(intention: AppIntention.Track) {
+        analytics.log(intention.event)
+    }
+}
+```
+
+Each matching intention spawns its own coroutine, so slow actions do not block each other. The wrapped result is routed through the `FlowUnitFeature` branch — outcomes are not collected.
+
+## TypedUnitFeature — typed streaming side effects
+
+Like `TypedFeature`, but returns `Flow<Unit>` for streaming side effects with no state contribution:
+
+```kotlin
+class ConnectivityWatcherFeature(
+    private val connectivity: Connectivity,
+) : TypedUnitFeature<AppState, AppIntention.WatchConnectivity> {
+    override fun invoke(intentions: Flow<AppIntention.WatchConnectivity>): Flow<Unit> =
+        intentions
+            .flatMapLatest { connectivity.observe() }
+            .map { /* push to a tracker, no Outcome */ }
+}
+```
+
 ## FlowFeature — low-level
 
 For features that need to handle multiple intention types or work with the raw `Flow<Any>`:
@@ -117,6 +148,8 @@ class LoggingFeature : Feature.FlowUnitFeature<AppState> {
         }
 }
 ```
+
+`Feature.FlowFeature<S>` (returns `Flow<Outcome<S>>`) and `Feature.FlowUnitFeature<S>` (returns `Flow<Unit>`) are the two raw shapes; the four typed wrappers above sugar these for the common cases.
 
 ## Combining Outcomes
 

--- a/site-docs/getting-started.md
+++ b/site-docs/getting-started.md
@@ -3,8 +3,8 @@
 ## Prerequisites
 
 - Android Studio Hedgehog or newer
-- Kotlin 2.0+
-- KSP plugin (for `@AutoState`/`@AutoFeature` code generation)
+- Kotlin 2.1+ (project itself builds on 2.3.20)
+- KSP plugin (for `@AutoState`/`@AutoFeature` code generation) — pin a version that matches your Kotlin version
 
 ## Installation
 
@@ -14,7 +14,8 @@ In your app module's `build.gradle.kts`:
 
 ```kotlin
 plugins {
-    id("com.google.devtools.ksp") version "2.0.21-1.0.28"
+    // Use a KSP version that matches your Kotlin version (e.g. "2.3.20-2.3.2")
+    id("com.google.devtools.ksp") version "<KSP_VERSION>"
 }
 ```
 

--- a/site-docs/index.md
+++ b/site-docs/index.md
@@ -26,8 +26,9 @@ MVI architecture brings predictability to UI state. YAMV makes it production-rea
 | `yamv` | `MviRuntime`, `MviStore`, `FeatureRouter`, feature builders |
 | `yamv-retainer` | `MviRetainedStore` (Android ViewModel + iOS) |
 | `yamv-hilt` | `hiltMviStore()` Compose helper |
-| `yamv-koin` | `koinMviStore()` / `mviStore {}` DSL |
-| `yamv-processor-hilt` | KSP: generates `*Store` retained store + `*FeaturesModule` |
+| `yamv-koin` | `koinMviStore<S, I>()` / `mviStore {}` DSL |
+| `yamv-processor-core` | DI-agnostic KSP utilities (`AutoStateDiscovery`, `AutoFeatureDiscovery`) |
+| `yamv-processor-hilt` | Hilt KSP: generates `*Store` retained store + `*FeaturesModule` |
 
 ## Quick Install
 

--- a/site-docs/multiplatform.md
+++ b/site-docs/multiplatform.md
@@ -19,9 +19,10 @@ YAMV supports Kotlin Multiplatform for sharing state logic between Android and i
 kotlin {
     sourceSets {
         commonMain.dependencies {
-            implementation("com.github.ktomek.yamv:yamv:VERSION")
-            implementation("com.github.ktomek.yamv:yamv-retainer:VERSION")
-            implementation("com.github.ktomek.yamv:yamv-koin:VERSION")
+            implementation("io.github.ktomek:yamv-core:VERSION")
+            implementation("io.github.ktomek:yamv:VERSION")
+            implementation("io.github.ktomek:yamv-retainer:VERSION")
+            implementation("io.github.ktomek:yamv-koin:VERSION")
         }
     }
 }


### PR DESCRIPTION
Closes #53.

## Summary
The docs had drifted from the public surface across several merged PRs. Audit and per-file fixes:

| File | Drift | Fix |
|---|---|---|
| `README.md` | Quick-start only mentioned `TypedFeature` | Added a four-row table covering all typed shapes (`FunctionTypedFeature`, `TypedFeature`, `ActionTypedFeature`, `TypedUnitFeature`) |
| `CLAUDE.md` | Module list missed `yamv-koin`, `yamv-hilt`, `yamv-processor-hilt-fixtures`; `:app` line stale; Feature levels missing two shapes | Module list now matches `settings.gradle`; Features section lists raw shapes + four typed wrappers |
| `site-docs/index.md` | Modules table missed `yamv-processor-core`; Koin row untyped | Added the module; row now `koinMviStore<S, I>()` |
| `site-docs/getting-started.md` | KSP plugin pinned at `2.0.21-1.0.28` (project on Kotlin 2.3.20) | Replaced pin with guidance to match Kotlin version |
| `site-docs/features.md` | No `ActionTypedFeature` / `TypedUnitFeature` sections; `.wrap()` blurb listed only two shapes | Added sections for both new shapes; `.wrap()` blurb covers all four |
| `site-docs/architecture.md` | Feature abstraction-level table had only three rows | Now six rows (two raw + four typed) |
| `site-docs/code-generation.md` | Generated `@AutoFeature` example used `@Multibinds` — generator actually emits `provideDefaults` + `@ElementsIntoSet`; companion-object example used `FunctionTypedFeature` only | Example now matches actual output; comment lists all four wrap-needing shapes |
| `site-docs/multiplatform.md` | Maven coords still `com.github.ktomek.yamv:*` (JitPack) after #35/#36 migration | Coords updated to `io.github.ktomek:*` |
| `site-docs/changelog.md` | `[Unreleased]` only listed `MviExceptionHandler` | Added Maven Central migration, module renames, typed Koin, race fix, `TypedUnitFeature`, KSP parity, fixtures module |

## Test plan
- [x] All file edits are docs-only — no code/build changes.
- [x] Maven coordinate strings (`io.github.ktomek:*`) match the actual `coordinates(…)` line in the root `build.gradle.kts`.
- [x] Generated `@AutoFeature` example verified against the real generator output in `:app:hilt:build/generated/ksp/.../CounterStateFeaturesModule.kt`.
- [x] Module names in `CLAUDE.md` cross-checked against `settings.gradle`.