### PR TITLE
[#60] fix: do not route CancellationException through MviExceptionHandler

### DIFF
--- a/yamv/src/main/kotlin/com/ktomek/yamv/intention/FeatureRouter.kt
+++ b/yamv/src/main/kotlin/com/ktomek/yamv/intention/FeatureRouter.kt
@@ -17,6 +17,7 @@ import com.ktomek.yamv.state.MviExceptionHandler
 import kotlinx.atomicfu.AtomicBoolean
 import kotlinx.atomicfu.AtomicInt
 import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -86,6 +87,8 @@ internal class FeatureRouter<S : State>(
             scope.launch(dispatcher) {
                 try {
                     processFeature(feature)
+                } catch (e: CancellationException) {
+                    throw e
                 } catch (@Suppress("TooGenericExceptionCaught") e: Throwable) {
                     Yamv.log(YamvLogLevel.ERROR, TAG, "Feature $feature failed: $e")
                     exceptionHandler.handle(
@@ -133,13 +136,7 @@ internal class FeatureRouter<S : State>(
             (f as? HasFeatureScope)?.featureScope?.cancel()
         }
 
-        featureJobs.forEach { job ->
-            try {
-                job.cancel()
-            } catch (e: Exception) {
-                Yamv.log(YamvLogLevel.WARN, TAG, "Error cancelling feature job: ${e.message}")
-            }
-        }
+        featureJobs.forEach(Job::cancel)
     }
 
     fun isDisposed(): Boolean = isDisposed.value

--- a/yamv/src/main/kotlin/com/ktomek/yamv/state/MviRuntime.kt
+++ b/yamv/src/main/kotlin/com/ktomek/yamv/state/MviRuntime.kt
@@ -10,6 +10,7 @@ import com.ktomek.yamv.intention.IntentionRouter
 import com.ktomek.yamv.logging.Yamv
 import com.ktomek.yamv.logging.YamvLogLevel
 import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
@@ -70,6 +71,8 @@ class MviRuntime<S : State>(
                 .scan(defaultState) { state, reducer ->
                     try {
                         reducer.reduce(state)
+                    } catch (e: CancellationException) {
+                        throw e
                     } catch (@Suppress("TooGenericExceptionCaught") e: Throwable) {
                         handleException(MviErrorContext(source = ErrorSource.REDUCER), e)
                         state
@@ -90,6 +93,8 @@ class MviRuntime<S : State>(
                     try {
                         Yamv.log(YamvLogLevel.DEBUG, TAG, "Effect emitted: $effect")
                         effectsFlow.emit(effect)
+                    } catch (e: CancellationException) {
+                        throw e
                     } catch (@Suppress("TooGenericExceptionCaught") e: Throwable) {
                         handleException(MviErrorContext(source = ErrorSource.EFFECT), e)
                     }
@@ -105,6 +110,8 @@ class MviRuntime<S : State>(
                 .collect { intention ->
                     try {
                         intentionRouter.dispatchIntention(intention)
+                    } catch (e: CancellationException) {
+                        throw e
                     } catch (@Suppress("TooGenericExceptionCaught") e: Throwable) {
                         handleException(
                             MviErrorContext(

--- a/yamv/src/test/kotlin/com/ktomek/yamv/state/MviRuntimeTest.kt
+++ b/yamv/src/test/kotlin/com/ktomek/yamv/state/MviRuntimeTest.kt
@@ -10,11 +10,13 @@ import com.ktomek.yamv.feature.Feature
 import com.ktomek.yamv.feature.Feature.FlowFeature
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 private interface TestState : State {
     val count: Int
@@ -173,4 +175,46 @@ class MviRuntimeTest {
         // Assert
         assertEquals(emissionCountBeforeClear, emissionCount)
     }
+
+    @Test
+    fun `GIVEN MviRuntime mid-emission WHEN cleared THEN exceptionHandler is never invoked for cancellation`() =
+        runTest {
+            // Arrange — a feature whose flow is suspended (collects but never emits) so
+            // that clear() must cancel it mid-collection.
+            val testDispatcher = StandardTestDispatcher(testScheduler)
+            val defaultState = TestStateImpl(count = 0)
+            val recordedThrowables = mutableListOf<Throwable>()
+            val recordedSources = mutableListOf<ErrorSource>()
+
+            val handler = MviExceptionHandler { context, e ->
+                recordedThrowables.add(e)
+                recordedSources.add(context.source)
+                throw e
+            }
+
+            val suspendingFeature = object : FlowFeature<TestState> {
+                override fun invoke(intentions: Flow<Any>): Flow<Outcome<TestState>> = flow {
+                    intentions.collect { /* suspend forever */ }
+                }
+            }
+
+            val runtime = MviRuntime(
+                features = setOf<Feature<TestState>>(suspendingFeature),
+                defaultState = defaultState,
+                dispatcherConfig = testDispatcherConfig(testDispatcher),
+                exceptionHandler = handler,
+            )
+
+            // Act — get into a steady state, then dispatch + cancel mid-flight.
+            testDispatcher.scheduler.advanceUntilIdle()
+            runtime.dispatch("any")
+            runtime.clear()
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // Assert — handler must not see anything; cancellation is not an error.
+            assertTrue(
+                recordedThrowables.isEmpty(),
+                "exceptionHandler invoked during clear() with: $recordedThrowables (sources=$recordedSources)",
+            )
+        }
 }


### PR DESCRIPTION
Closes #60.

## Summary
On `MviRetainedStore.onCleared` → `MviRuntime.clear` → `scope.cancel`, every active collector inside `MviRuntime` and every per-feature coroutine inside `FeatureRouter` receives a `JobCancellationException`. Four catch sites funneled that into `handleException` → the user's `MviExceptionHandler`, so a Crashlytics handler would report each clean shutdown as a crash.

### Catch sites fixed
- `MviRuntime.kt:73` — reducer `scan` catch (`ErrorSource.REDUCER`)
- `MviRuntime.kt:93` — effect collect catch (`ErrorSource.EFFECT`)
- `MviRuntime.kt:108` — intention re-dispatch catch (`ErrorSource.INTENTION_REDISPATCH`)
- `FeatureRouter.kt:88` — per-feature `processFeature` catch (`ErrorSource.FEATURE`) — this one was claimed as already correct in the issue body, but actually wasn't; the new test caught it during verification

Each site now catches `CancellationException` first and rethrows so structured cancellation continues uninterrupted, before the broader `Throwable` catch routes real errors to the handler.

### Cleanup
`FeatureRouter.shutdown` had a `try { job.cancel() } catch (e: Exception) { Yamv.log(WARN, ...) }` block. `Job.cancel` doesn't throw — dead code with a misleading log. Replaced with `featureJobs.forEach(Job::cancel)`.

### New test
`MviRuntimeTest`: a feature whose flow suspends mid-collection, dispatch one intention, call `clear()`, assert the supplied `MviExceptionHandler` was *never* invoked. This is the test that caught the missing filter in `FeatureRouter`.

## Test plan
- [x] `./gradlew :yamv:jvmTest` — 119 + 1 new test, all green
- [x] `./gradlew :yamv:jvmTest detektAll build` — full multi-module green