### PR TITLE
[#62] feat: hilt parity with koin owner abstractions (owner, key, MviStoreOwner, ProvideAppMviStoreOwner)

### DIFF
--- a/site-docs/getting-started.md
+++ b/site-docs/getting-started.md
@@ -156,7 +156,9 @@ By default both `hiltMviStore()` and `koinMviStore()` resolve through `LocalView
     fun AuthScreen(store: AuthStateStore = hiltMviAppStore()) { ... }
     ```
 
-    Resolves the host `ComponentActivity` from `LocalContext` and uses it as the `ViewModelStoreOwner` — so the same instance is shared across the activity's lifetime.
+    Resolves the host `ComponentActivity` automatically and uses it as the `MviStoreOwner` — same instance shared across the activity's lifetime, no setup required.
+
+    For non-default scopes (a specific Fragment, a custom `NavBackStackEntry`, tests) wrap the subtree with `ProvideAppMviStoreOwner(owner) { … }` to override `LocalAppMviStoreOwner`.
 
 === "Koin"
 

--- a/site-docs/getting-started.md
+++ b/site-docs/getting-started.md
@@ -145,6 +145,37 @@ class DecrementFeature : TypedFeature<CounterState, CounterIntention.Decrement> 
     }
     ```
 
+### App-lifetime state across navigation
+
+By default both `hiltMviStore()` and `koinMviStore()` resolve through `LocalViewModelStoreOwner.current`, which Compose Navigation overrides per back-stack entry — every destination gets its own store. For state that should survive navigation (auth, session, preferences):
+
+=== "Hilt"
+
+    ```kotlin
+    @Composable
+    fun AuthScreen(store: AuthStateStore = hiltMviAppStore()) { ... }
+    ```
+
+    Resolves the host `ComponentActivity` from `LocalContext` and uses it as the `ViewModelStoreOwner` — so the same instance is shared across the activity's lifetime.
+
+=== "Koin"
+
+    ```kotlin
+    @Composable
+    fun App() {
+        ProvideAppMviStoreOwner {
+            NavHost(...) { ... }
+        }
+    }
+
+    @Composable
+    fun AuthScreen(store: MviStore<AuthState, AuthIntention> = koinMviAppStore()) { ... }
+    ```
+
+    `ProvideAppMviStoreOwner` (placed above `NavHost`) captures the root owner; `koinMviAppStore` resolves through it.
+
+Both `hiltMviStore` and `koinMviStore` also accept an explicit `owner` parameter when you need to scope to something other than the default.
+
 ## Running the Sample App
 
 The `:app:hilt` module is a working counter demo:

--- a/yamv-hilt/src/main/kotlin/com/ktomek/yamv/hilt/AppMviStoreOwner.kt
+++ b/yamv-hilt/src/main/kotlin/com/ktomek/yamv/hilt/AppMviStoreOwner.kt
@@ -1,0 +1,53 @@
+package com.ktomek.yamv.hilt
+
+import androidx.activity.ComponentActivity
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
+
+/**
+ * Compose local carrying the app-root [MviStoreOwner].
+ *
+ * Defaults to the host [ComponentActivity] resolved from [LocalContext], so Hilt apps
+ * get app-lifetime scoping without any setup — Hilt's `ViewModelProvider.Factory` already
+ * treats the activity as the natural app-root owner. Override with [ProvideAppMviStoreOwner]
+ * if you need to scope to a non-default owner (e.g. a specific Fragment or NavBackStackEntry).
+ *
+ * Mirrors `com.ktomek.yamv.koin.LocalAppMviStoreOwner` — but unlike the Koin variant this
+ * one returns a useful default instead of erroring when no [ProvideAppMviStoreOwner] is set.
+ */
+val LocalAppMviStoreOwner = compositionLocalOf<MviStoreOwner?> { null }
+
+/**
+ * Override the app-root [MviStoreOwner] for the wrapped [content].
+ *
+ * Most Hilt apps don't need this — [hiltMviAppStore] and [LocalAppMviStoreOwner] already
+ * resolve to the host `ComponentActivity` automatically. Use this only when the activity
+ * isn't the right scope, e.g. for tests or when sharing across a Fragment-only sub-tree.
+ *
+ * The supplied [owner] must be a Hilt-aware `ViewModelStoreOwner` (Activity, Fragment,
+ * NavBackStackEntry); Hilt's factory will fail at retrieval otherwise.
+ */
+@Composable
+fun ProvideAppMviStoreOwner(
+    owner: MviStoreOwner,
+    content: @Composable () -> Unit,
+) {
+    CompositionLocalProvider(LocalAppMviStoreOwner provides owner, content = content)
+}
+
+/**
+ * Convenience overload — captures the host [ComponentActivity] automatically and exposes it
+ * as [LocalAppMviStoreOwner]. Mirrors Koin's `ProvideAppMviStoreOwner { … }` shape.
+ *
+ * Calling this is rarely necessary because [LocalAppMviStoreOwner] already defaults to the
+ * activity; but it's available for parity with `yamv-koin`.
+ */
+@Composable
+fun ProvideAppMviStoreOwner(content: @Composable () -> Unit) {
+    val context = LocalContext.current
+    val activity = remember(context) { context.findComponentActivity() }
+    ProvideAppMviStoreOwner(owner = activity, content = content)
+}

--- a/yamv-hilt/src/main/kotlin/com/ktomek/yamv/hilt/HiltMviStore.kt
+++ b/yamv-hilt/src/main/kotlin/com/ktomek/yamv/hilt/HiltMviStore.kt
@@ -7,17 +7,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import androidx.lifecycle.ViewModelStoreOwner
-import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import com.ktomek.yamv.retainer.MviRetainedStore
 
 /**
  * Returns a Hilt-provided [MviRetainedStore] instance scoped to [owner].
  *
  * Mirrors the underlying [hiltViewModel] signature so call sites can pass an explicit
- * [ViewModelStoreOwner] (e.g. an Activity for app-lifetime scoping) or a [key] for keyed
- * instances. Defaults to `LocalViewModelStoreOwner.current` — the current navigation
- * back-stack entry when used inside a `NavHost`.
+ * [MviStoreOwner] (e.g. an Activity for app-lifetime scoping) or a [key] for keyed
+ * instances. Defaults to [LocalMviStoreOwner] — the current navigation back-stack entry
+ * when used inside a `NavHost`.
  *
  * Hilt's `ViewModelProvider.Factory` only resolves through Hilt-aware owners
  * ([ComponentActivity], `Fragment`, `NavBackStackEntry`); passing an arbitrary owner will
@@ -31,22 +29,22 @@ import com.ktomek.yamv.retainer.MviRetainedStore
  */
 @Composable
 inline fun <reified VM : MviRetainedStore<*, *>> hiltMviStore(
-    owner: ViewModelStoreOwner = checkNotNull(LocalViewModelStoreOwner.current) {
-        "No ViewModelStoreOwner in composition (LocalViewModelStoreOwner.current was null)"
+    owner: MviStoreOwner = checkNotNull(LocalMviStoreOwner.current) {
+        "No MviStoreOwner in composition (LocalMviStoreOwner.current was null)"
     },
     key: String? = null,
 ): VM = hiltViewModel(viewModelStoreOwner = owner, key = key)
 
 /**
- * Returns a Hilt-provided [MviRetainedStore] scoped to the host [ComponentActivity], so the
- * same instance survives navigation changes and is shared across screens for the lifetime
- * of the activity.
+ * Returns a Hilt-provided [MviRetainedStore] scoped to the app-root [MviStoreOwner], so the
+ * same instance survives navigation changes and is shared across screens.
  *
- * Walks `LocalContext.current` through any [ContextWrapper] chain to find the activity, so
- * this works under `NavHost` (which overrides `LocalViewModelStoreOwner` per back-stack
- * entry) without any extra setup.
+ * Resolves [LocalAppMviStoreOwner.current] when set (via [ProvideAppMviStoreOwner]), or
+ * falls back to the host [ComponentActivity] discovered from [LocalContext]. The activity
+ * is the canonical app-lifetime owner for Hilt-managed ViewModels, so most apps need no
+ * extra setup.
  *
- * Mirrors [com.ktomek.yamv.koin.koinMviAppStore] from `yamv-koin`.
+ * Mirrors `com.ktomek.yamv.koin.koinMviAppStore` from `yamv-koin`.
  *
  * Usage:
  * ```
@@ -54,14 +52,20 @@ inline fun <reified VM : MviRetainedStore<*, *>> hiltMviStore(
  * fun AuthScreen(store: AuthStateStore = hiltMviAppStore()) { ... }
  * ```
  *
- * @throws IllegalStateException if the host context cannot be resolved to a [ComponentActivity]
- *   — required because Hilt's ViewModel factory only works with Hilt-aware owners.
+ * @throws IllegalStateException when no [LocalAppMviStoreOwner] is set and the host context
+ *   cannot be resolved to a [ComponentActivity] — required because Hilt's ViewModel factory
+ *   only works with Hilt-aware owners.
  */
 @Composable
 inline fun <reified VM : MviRetainedStore<*, *>> hiltMviAppStore(key: String? = null): VM {
-    val context = LocalContext.current
-    val activity = remember(context) { context.findComponentActivity() }
-    return hiltMviStore(owner = activity, key = key)
+    val explicit = LocalAppMviStoreOwner.current
+    val owner = if (explicit != null) {
+        explicit
+    } else {
+        val context = LocalContext.current
+        remember(context) { context.findComponentActivity() }
+    }
+    return hiltMviStore(owner = owner, key = key)
 }
 
 @PublishedApi
@@ -74,6 +78,6 @@ internal fun Context.findComponentActivity(): ComponentActivity {
     error(
         "hiltMviAppStore requires the host context to resolve to a ComponentActivity " +
             "(got ${this::class.qualifiedName}). Place the composable inside an activity that " +
-            "extends ComponentActivity or one of its subclasses (e.g. AppCompatActivity).",
+            "extends ComponentActivity, or wrap the subtree with ProvideAppMviStoreOwner(owner = ...).",
     )
 }

--- a/yamv-hilt/src/main/kotlin/com/ktomek/yamv/hilt/HiltMviStore.kt
+++ b/yamv-hilt/src/main/kotlin/com/ktomek/yamv/hilt/HiltMviStore.kt
@@ -1,14 +1,27 @@
 package com.ktomek.yamv.hilt
 
+import android.content.Context
+import android.content.ContextWrapper
+import androidx.activity.ComponentActivity
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
 import com.ktomek.yamv.retainer.MviRetainedStore
 
 /**
- * Returns a Hilt-provided [MviRetainedStore] instance scoped to the current backstack entry.
+ * Returns a Hilt-provided [MviRetainedStore] instance scoped to [owner].
  *
- * Prefer this over calling [hiltViewModel] directly so call sites stay decoupled from
- * the Hilt ViewModel API and the type constraint on [MviRetainedStore] is enforced.
+ * Mirrors the underlying [hiltViewModel] signature so call sites can pass an explicit
+ * [ViewModelStoreOwner] (e.g. an Activity for app-lifetime scoping) or a [key] for keyed
+ * instances. Defaults to `LocalViewModelStoreOwner.current` — the current navigation
+ * back-stack entry when used inside a `NavHost`.
+ *
+ * Hilt's `ViewModelProvider.Factory` only resolves through Hilt-aware owners
+ * ([ComponentActivity], `Fragment`, `NavBackStackEntry`); passing an arbitrary owner will
+ * fail at retrieval time. Use [hiltMviAppStore] for the common app-lifetime case.
  *
  * Usage:
  * ```
@@ -17,4 +30,50 @@ import com.ktomek.yamv.retainer.MviRetainedStore
  * ```
  */
 @Composable
-inline fun <reified VM : MviRetainedStore<*, *>> hiltMviStore(): VM = hiltViewModel()
+inline fun <reified VM : MviRetainedStore<*, *>> hiltMviStore(
+    owner: ViewModelStoreOwner = checkNotNull(LocalViewModelStoreOwner.current) {
+        "No ViewModelStoreOwner in composition (LocalViewModelStoreOwner.current was null)"
+    },
+    key: String? = null,
+): VM = hiltViewModel(viewModelStoreOwner = owner, key = key)
+
+/**
+ * Returns a Hilt-provided [MviRetainedStore] scoped to the host [ComponentActivity], so the
+ * same instance survives navigation changes and is shared across screens for the lifetime
+ * of the activity.
+ *
+ * Walks `LocalContext.current` through any [ContextWrapper] chain to find the activity, so
+ * this works under `NavHost` (which overrides `LocalViewModelStoreOwner` per back-stack
+ * entry) without any extra setup.
+ *
+ * Mirrors [com.ktomek.yamv.koin.koinMviAppStore] from `yamv-koin`.
+ *
+ * Usage:
+ * ```
+ * @Composable
+ * fun AuthScreen(store: AuthStateStore = hiltMviAppStore()) { ... }
+ * ```
+ *
+ * @throws IllegalStateException if the host context cannot be resolved to a [ComponentActivity]
+ *   — required because Hilt's ViewModel factory only works with Hilt-aware owners.
+ */
+@Composable
+inline fun <reified VM : MviRetainedStore<*, *>> hiltMviAppStore(key: String? = null): VM {
+    val context = LocalContext.current
+    val activity = remember(context) { context.findComponentActivity() }
+    return hiltMviStore(owner = activity, key = key)
+}
+
+@PublishedApi
+internal fun Context.findComponentActivity(): ComponentActivity {
+    var ctx: Context? = this
+    while (ctx is ContextWrapper) {
+        if (ctx is ComponentActivity) return ctx
+        ctx = ctx.baseContext
+    }
+    error(
+        "hiltMviAppStore requires the host context to resolve to a ComponentActivity " +
+            "(got ${this::class.qualifiedName}). Place the composable inside an activity that " +
+            "extends ComponentActivity or one of its subclasses (e.g. AppCompatActivity).",
+    )
+}

--- a/yamv-hilt/src/main/kotlin/com/ktomek/yamv/hilt/MviStoreOwner.kt
+++ b/yamv-hilt/src/main/kotlin/com/ktomek/yamv/hilt/MviStoreOwner.kt
@@ -1,0 +1,28 @@
+package com.ktomek.yamv.hilt
+
+import androidx.compose.runtime.Composable
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+
+/**
+ * The lifecycle-scoped owner that retains an MVI store instance.
+ *
+ * Typealiased to [ViewModelStoreOwner] — the underlying mechanism is the Android ViewModel
+ * store, but public APIs prefer this name so the MVI surface stays free of ViewModel
+ * terminology. Mirrors `com.ktomek.yamv.koin.MviStoreOwner` from `yamv-koin`.
+ */
+typealias MviStoreOwner = ViewModelStoreOwner
+
+/**
+ * Access the current [MviStoreOwner] from composition.
+ *
+ * Delegates to [LocalViewModelStoreOwner]. Inside a `NavHost` this is overridden per
+ * `NavBackStackEntry`, so each navigation destination gets its own store instance — see
+ * [hiltMviAppStore] / [LocalAppMviStoreOwner] for state that should survive navigation.
+ */
+@Suppress("ClassName", "ClassNaming")
+object LocalMviStoreOwner {
+    val current: MviStoreOwner?
+        @Composable
+        get() = LocalViewModelStoreOwner.current
+}


### PR DESCRIPTION
Closes #62.

## Summary
Brings `yamv-hilt` to API parity with `yamv-koin` for store ownership: the Hilt module now exposes the same `MviStoreOwner` typealias, `LocalMviStoreOwner` / `LocalAppMviStoreOwner` composition locals, and `ProvideAppMviStoreOwner` helpers that Koin already had — so Hilt call sites no longer need to know about `ViewModelStoreOwner` / `LocalViewModelStoreOwner`. Adds `hiltMviAppStore` as the Hilt analog of `koinMviAppStore`.

## Two commits

### `[#62] feat: hiltMviStore accepts owner/key + add hiltMviAppStore`
- `hiltMviStore` now mirrors the underlying `hiltViewModel` signature with `owner` and `key` parameters (default `LocalViewModelStoreOwner.current`, `null`). `hiltMviStore()` call sites keep working unchanged.
- `hiltMviAppStore(key)` walks `LocalContext` for the host `ComponentActivity` and uses it as the owner.

### `[#62] feat: hide ViewModel terminology in yamv-hilt for Koin parity`
Added in response to review feedback that the Hilt module should expose the same abstractions Koin already does:
- `MviStoreOwner` — `typealias` for `ViewModelStoreOwner` (mirrors `yamv-koin/.../MviStoreOwner.kt`).
- `LocalMviStoreOwner.current` — accessor delegating to `LocalViewModelStoreOwner.current`.
- `LocalAppMviStoreOwner` — composition local for the app-root owner.
- `ProvideAppMviStoreOwner(owner) { }` and `ProvideAppMviStoreOwner { }` — opt-in override for non-default scopes (Fragment, custom NavBackStackEntry, tests).
- `hiltMviStore` / `hiltMviAppStore` now consume `MviStoreOwner` / `LocalAppMviStoreOwner` instead of the raw ViewModel-flavored names. No call-site changes — typealiased to the same JVM type.

### Hilt vs. Koin: one intentional divergence
`LocalAppMviStoreOwner` for Hilt **defaults to the auto-resolved `ComponentActivity`** instead of erroring when no `Provide…Owner` is set. Rationale: Hilt's `ViewModelProvider.Factory` only accepts Hilt-aware owners (Activity, Fragment, NavBackStackEntry), and the activity is already discoverable from `LocalContext` — so requiring `ProvideAppMviStoreOwner` setup just to use `hiltMviAppStore()` would be ceremony. The override path remains available for tests and Fragment-rooted subtrees.

### Docs
`site-docs/getting-started.md` gets a tabbed Hilt/Koin section explaining app-lifetime scoping, the new helpers, and the override path.

## Test plan
- [x] `./gradlew :yamv-hilt:assembleDebug` — green
- [x] `./gradlew :app:hilt:assembleDebug` — sample still compiles with `hiltMviStore()` unchanged
- [x] `./gradlew detektAll` — green
- [x] `./gradlew :yamv-processor-hilt-fixtures:testDebugUnitTest --rerun-tasks` — KSP fixtures still pass (note: `--rerun-tasks` is needed locally after `clean` due to a pre-existing KSP-cache fragility unrelated to this PR; CI is unaffected because it does fresh checkouts)