### PR TITLE
[#64] feat: dispatch sugar — store(intention) + store send intention on MviStore

### DIFF
--- a/site-docs/getting-started.md
+++ b/site-docs/getting-started.md
@@ -145,6 +145,8 @@ class DecrementFeature : TypedFeature<CounterState, CounterIntention.Decrement> 
     }
     ```
 
+`store.dispatch(intention)`, `store(intention)` (operator), and `store send intention` (infix) are equivalent — pick whichever reads best at the call site.
+
 ### App-lifetime state across navigation
 
 By default both `hiltMviStore()` and `koinMviStore()` resolve through `LocalViewModelStoreOwner.current`, which Compose Navigation overrides per back-stack entry — every destination gets its own store. For state that should survive navigation (auth, session, preferences):

--- a/yamv/src/main/kotlin/com/ktomek/yamv/state/MviStore.kt
+++ b/yamv/src/main/kotlin/com/ktomek/yamv/state/MviStore.kt
@@ -10,4 +10,10 @@ interface MviStore<S : State, I : Any> {
     val effects: Flow<EffectOutcome<S>>
     fun dispatch(intention: I)
     fun clear()
+
+    /** Sugar — `store(intention)` is equivalent to `store.dispatch(intention)`. */
+    operator fun invoke(intention: I) = dispatch(intention)
+
+    /** Sugar — `store send intention` is equivalent to `store.dispatch(intention)`. */
+    infix fun send(intention: I) = dispatch(intention)
 }

--- a/yamv/src/test/kotlin/com/ktomek/yamv/state/MviRuntimeTest.kt
+++ b/yamv/src/test/kotlin/com/ktomek/yamv/state/MviRuntimeTest.kt
@@ -217,4 +217,58 @@ class MviRuntimeTest {
                 "exceptionHandler invoked during clear() with: $recordedThrowables (sources=$recordedSources)",
             )
         }
+
+    @Test
+    fun `GIVEN MviRuntime WHEN intention dispatched via invoke operator THEN state is updated`() =
+        runTest {
+            // Arrange
+            val testDispatcher = StandardTestDispatcher(testScheduler)
+            val defaultState = TestStateImpl(count = 0)
+            val incrementReducer: StateOutcome<TestState> = StateOutcome { prev -> TestStateImpl(prev.count + 1) }
+
+            val feature = object : FlowFeature<TestState> {
+                override fun invoke(intentions: Flow<Any>): Flow<Outcome<TestState>> =
+                    intentions.map { incrementReducer }
+            }
+
+            val runtime = MviRuntime(
+                features = setOf<Feature<TestState>>(feature),
+                defaultState = defaultState,
+                dispatcherConfig = testDispatcherConfig(testDispatcher),
+            )
+
+            // Act — operator-invoke sugar instead of .dispatch
+            runtime("any_intention")
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // Assert
+            assertEquals(1, runtime.state.value.count)
+        }
+
+    @Test
+    fun `GIVEN MviRuntime WHEN intention dispatched via send infix THEN state is updated`() =
+        runTest {
+            // Arrange
+            val testDispatcher = StandardTestDispatcher(testScheduler)
+            val defaultState = TestStateImpl(count = 0)
+            val incrementReducer: StateOutcome<TestState> = StateOutcome { prev -> TestStateImpl(prev.count + 1) }
+
+            val feature = object : FlowFeature<TestState> {
+                override fun invoke(intentions: Flow<Any>): Flow<Outcome<TestState>> =
+                    intentions.map { incrementReducer }
+            }
+
+            val runtime = MviRuntime(
+                features = setOf<Feature<TestState>>(feature),
+                defaultState = defaultState,
+                dispatcherConfig = testDispatcherConfig(testDispatcher),
+            )
+
+            // Act — infix-send sugar instead of .dispatch
+            runtime send "any_intention"
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            // Assert
+            assertEquals(1, runtime.state.value.count)
+        }
 }


### PR DESCRIPTION
Closes #64.

## Summary
Two default methods on the `MviStore<S, I>` interface that desugar to `dispatch(intention)`:

```kotlin
interface MviStore<S : State, I : Any> {
    fun dispatch(intention: I)

    /** Sugar — store(intention) is equivalent to store.dispatch(intention). */
    operator fun invoke(intention: I) = dispatch(intention)

    /** Sugar — store send intention is equivalent to store.dispatch(intention). */
    infix fun send(intention: I) = dispatch(intention)
}
```

All three call shapes are equivalent — pick whichever reads best at the call site:
```kotlin
store.dispatch(IncreaseCounterIntention)
store(IncreaseCounterIntention)
store send IncreaseCounterIntention
```

`dispatch` stays as the canonical, grep-able method; the sugar is purely additive.

### Considered and rejected
`operator fun plus` (`store + Intention`). `+` carries value-semantic expectations (sums, collection composition); applying it to a fire-and-forget side-effect dispatch reads as cute-but-wrong.

## Implementation notes
- Added as **default interface methods** (not extensions). All existing implementers (`MviRuntime`, `MviRetainedStore`, `KoinMviRetainedStore`, the `TestMviRetainedStore` fake) were verified clean — none define `invoke` or `send`, so no conflicts.
- Two new `MviRuntimeTest` cases clone the existing dispatch state-update test, calling through the operator-invoke and infix-send shapes respectively.
- `site-docs/getting-started.md` gains a one-line note after step 5 listing the three equivalent shapes.

## Test plan
- [x] `./gradlew :yamv:jvmTest --tests "com.ktomek.yamv.state.MviRuntimeTest"` — 121 tests, all green
- [x] `./gradlew detektAll build` — full multi-module green (note: a `--rerun-tasks` was needed locally on the KSP fixtures task due to the pre-existing cache fragility flagged in PR #58/#63; CI is unaffected)